### PR TITLE
Improve clarity around BatchKeyFn function usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ IDs each:
 IDs can often be fetched from multiple data sources. Hence, we'll want to
 prefix the ID in order to make the cache key unique. The package provides more
 functionality for this that we'll see later on, but for now we'll use the most
-simple version which adds a string prefix to every ID:
+simple version which adds a string prefix together with a seperator to every ID:
 
 ```go
 	keyPrefixFn := cacheClient.BatchKeyFn("my-data-source")
@@ -803,11 +803,12 @@ func NewAPI(c *sturdyc.Client[string]) *API {
 }
 
 func (a *API) GetBatch(ctx context.Context, ids []string) (map[string]string, error) {
-	// We are going to use a cache a key function that prefixes each id.
+	// We are going to pass the cache a key function that prefixes each id with the provided prefix and "-ID-".
 	// This makes it possible to save the same id for different data sources.
 	cacheKeyFn := a.BatchKeyFn("some-prefix")
 
 	// The fetchFn is only going to retrieve the IDs that are not in the cache.
+	// The cacheMisses will contain the missing IDs and not the formatted keys.
 	fetchFn := func(_ context.Context, cacheMisses []string) (map[string]string, error) {
 		log.Printf("Cache miss. Fetching ids: %s\n", strings.Join(cacheMisses, ", "))
 		// Batch functions should return a map where the key is the id of the record.

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -60,8 +60,8 @@ func demonstrateGetOrFetchBatch(cacheClient *sturdyc.Client[int]) {
 		{"11", "12", "13", "14", "15"},
 	}
 
-	// We'll use a cache key function to add a prefix to the IDs. If we only used
-	// the IDs, we wouldn't be able to fetch the same IDs from multiple data sources.
+	// We are going use a cache key function that prefixes each id with the provided prefix and "-ID-".
+	// If we only used the IDs, we wouldn't be able to fetch the same IDs from multiple data sources.
 	keyPrefixFn := cacheClient.BatchKeyFn("my-data-source")
 
 	// Request the keys  for each batch.

--- a/examples/batch/main.go
+++ b/examples/batch/main.go
@@ -25,7 +25,7 @@ func (a *API) GetBatch(ctx context.Context, ids []string) (map[string]string, er
 	cacheKeyFn := a.BatchKeyFn("some-prefix")
 
 	// The fetchFn is only going to retrieve the IDs that are not in the cache.
-	// The cacheMisses will contain the missing IDs without the prefix.
+	// The cacheMisses will contain the missing IDs and not the formatted keys.
 	fetchFn := func(_ context.Context, cacheMisses []string) (map[string]string, error) {
 		log.Printf("Cache miss. Fetching ids: %s\n", strings.Join(cacheMisses, ", "))
 		// Batch functions should return a map where the key is the id of the record.

--- a/examples/batch/main.go
+++ b/examples/batch/main.go
@@ -20,11 +20,12 @@ func NewAPI(c *sturdyc.Client[string]) *API {
 }
 
 func (a *API) GetBatch(ctx context.Context, ids []string) (map[string]string, error) {
-	// We are going to pass the cache a key function that prefixes each id.
+	// We are going to pass the cache a key function that prefixes each id with the provided prefix and "-ID-".
 	// This makes it possible to save the same id for different data sources.
 	cacheKeyFn := a.BatchKeyFn("some-prefix")
 
 	// The fetchFn is only going to retrieve the IDs that are not in the cache.
+	// The cacheMisses will contain the missing IDs without the prefix.
 	fetchFn := func(_ context.Context, cacheMisses []string) (map[string]string, error) {
 		log.Printf("Cache miss. Fetching ids: %s\n", strings.Join(cacheMisses, ", "))
 		// Batch functions should return a map where the key is the id of the record.

--- a/examples/buffering/main.go
+++ b/examples/buffering/main.go
@@ -23,7 +23,7 @@ func NewOrderAPI(client *sturdyc.Client[string]) *OrderAPI {
 }
 
 func (a *OrderAPI) OrderStatus(ctx context.Context, ids []string, opts OrderOptions) (map[string]string, error) {
-	// We use the  PermutedBatchKeyFn when an ID isn't enough to uniquely identify a
+	// We use the PermutedBatchKeyFn when an ID isn't enough to uniquely identify a
 	// record. The cache is going to store each id once per set of options. In a more
 	// realistic scenario, the opts would be query params or arguments to a DB query.
 	cacheKeyFn := a.PermutatedBatchKeyFn("key", opts)

--- a/examples/permutations/main.go
+++ b/examples/permutations/main.go
@@ -23,7 +23,7 @@ func NewOrderAPI(c *sturdyc.Client[string]) *OrderAPI {
 }
 
 func (a *OrderAPI) OrderStatus(ctx context.Context, ids []string, opts OrderOptions) (map[string]string, error) {
-	// We use the  PermutedBatchKeyFn when an ID isn't enough to uniquely identify a
+	// We use the PermutedBatchKeyFn when an ID isn't enough to uniquely identify a
 	// record. The cache is going to store each id once per set of options. In a more
 	// realistic scenario, the opts would be query params or arguments to a DB query.
 	cacheKeyFn := a.PermutatedBatchKeyFn("key", opts)

--- a/keys.go
+++ b/keys.go
@@ -158,8 +158,8 @@ func (c *Client[T]) PermutatedKey(prefix string, permutationStruct interface{}) 
 }
 
 // BatchKeyFn provides a function that can be used in conjunction with
-// "GetOrFetchBatch". It takes in a prefix and returns a function that will
-// append the ID as a suffix for each item.
+// "GetOrFetchBatch". It takes in a prefix and returns a function that will format
+// a string with the prefix and id seperated by "-ID-" for each item.
 //
 // Parameters:
 //
@@ -167,7 +167,7 @@ func (c *Client[T]) PermutatedKey(prefix string, permutationStruct interface{}) 
 //
 // Returns:
 //
-//	A function that takes an ID and returns a cache key string with the given prefix and ID.
+//	A function that takes an ID and returns a cache key string with the given prefix and ID seperated by "-ID-".
 func (c *Client[T]) BatchKeyFn(prefix string) KeyFn {
 	return func(id string) string {
 		return fmt.Sprintf("%s-ID-%s", prefix, id)
@@ -189,7 +189,7 @@ func (c *Client[T]) BatchKeyFn(prefix string) KeyFn {
 //
 // Returns:
 //
-//	A function that takes an ID and returns a cache key string with the given prefix, permutation struct fields, and ID.
+//	A function that takes an ID and returns a cache key string with the given prefix and permutation struct fields followed by "-ID-" and the ID.
 func (c *Client[T]) PermutatedBatchKeyFn(prefix string, permutationStruct interface{}) KeyFn {
 	return func(id string) string {
 		key := c.PermutatedKey(prefix, permutationStruct)


### PR DESCRIPTION
Hi,

first of all amazing library.
The documentation, examples and structure make it really easy and fun to implement.

I am opening this pull request to suggest a small change in the documentation around the BatchKeyFn.
From the current documentation I always thought that the function only combines the two strings (prefix and id).
But after troubleshooting and checking the code I realized it uses a "<prefix>-ID-<id>" format which was not described anywhere. This lead to an issue for me as I prefixed the keys myself when using the SetMany function.

In addition to the documentation changes, I would also suggest replacing the "magic formatting/string" with a exported variable as this makes it easier to prefix the keys when the BatchKeyFn is not applicable.