### PR TITLE
Feat: key aliases

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -419,6 +419,19 @@ func TestAliases(t *testing.T) {
 			},
 			shouldPanic: true,
 		},
+		{
+			name: "Key functions are applied to aliases",
+			init: func(client *sturdyc.Client[string]) {
+				client.Set("key-with-aliases", "value", sturdyc.WithAliasKeys([]string{"alias1", "alias2"}), sturdyc.WithSetKeyFn(func(key string) string {
+					return fmt.Sprintf("prefix:%s", key)
+				}))
+			},
+			items: []AliasTestItem{
+				{key: "prefix:key-with-aliases", value: "value", shouldExist: true},
+				{key: "prefix:alias1", value: "value", shouldExist: true},
+				{key: "prefix:alias2", value: "value", shouldExist: true},
+			},
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/inflight.go
+++ b/inflight.go
@@ -32,9 +32,9 @@ func makeCall[T, V any](ctx context.Context, c *Client[T], key string, fn FetchF
 		c.inFlightMutex.Unlock()
 	}()
 
-	response, aliases, err := fn(ctx)
+	response, err := fn(ctx)
 	if err != nil && c.storeMissingRecords && errors.Is(err, ErrNotFound) {
-		c.StoreMissingRecord(key, aliases)
+		c.StoreMissingRecord(key)
 		call.err = ErrMissingRecord
 		return
 	}
@@ -52,7 +52,7 @@ func makeCall[T, V any](ctx context.Context, c *Client[T], key string, fn FetchF
 
 	call.err = nil
 	call.val = res
-	c.Set(key, res, aliases)
+	c.Set(key, res)
 }
 
 func callAndCache[V, T any](ctx context.Context, c *Client[T], key string, fn FetchFn[V]) (V, error) {
@@ -97,7 +97,7 @@ type makeBatchCallOpts[T, V any] struct {
 }
 
 func makeBatchCall[T, V any](ctx context.Context, c *Client[T], opts makeBatchCallOpts[T, V]) {
-	response, aliases, err := opts.fn(ctx, opts.ids)
+	response, err := opts.fn(ctx, opts.ids)
 	if err != nil && !errors.Is(err, errOnlyDistributedRecords) {
 		opts.call.err = err
 		return
@@ -115,7 +115,7 @@ func makeBatchCall[T, V any](ctx context.Context, c *Client[T], opts makeBatchCa
 	if c.storeMissingRecords && len(response) < len(opts.ids) && !errors.Is(err, errOnlyDistributedRecords) {
 		for _, id := range opts.ids {
 			if _, ok := response[id]; !ok {
-				c.StoreMissingRecord(opts.keyFn(id), aliases[id])
+				c.StoreMissingRecord(opts.keyFn(id))
 			}
 		}
 	}
@@ -127,7 +127,7 @@ func makeBatchCall[T, V any](ctx context.Context, c *Client[T], opts makeBatchCa
 			c.log.Error("sturdyc: invalid type for ID:" + id)
 			continue
 		}
-		c.Set(opts.keyFn(id), v, aliases[id])
+		c.Set(opts.keyFn(id), v)
 		opts.call.val[id] = v
 	}
 }

--- a/shard.go
+++ b/shard.go
@@ -23,6 +23,8 @@ type shard[T any] struct {
 	capacity           int
 	ttl                time.Duration
 	entries            map[string]*entry[T]
+	entriesByAlias     map[string]string
+	aliasesByEntry     map[string][]string
 	evictionPercentage int
 }
 
@@ -34,6 +36,8 @@ func newShard[T any](capacity int, ttl time.Duration, evictionPercentage int, cf
 		ttl:                ttl,
 		entries:            make(map[string]*entry[T]),
 		evictionPercentage: evictionPercentage,
+		entriesByAlias:     make(map[string]string),
+		aliasesByEntry:     make(map[string][]string),
 	}
 }
 
@@ -72,11 +76,43 @@ func (s *shard[T]) forceEvict() {
 	entriesEvicted := 0
 	for key, e := range s.entries {
 		if e.expiresAt.Before(cutoff) {
-			delete(s.entries, key)
+			s.unsafeDelete(key)
 			entriesEvicted++
 		}
 	}
 	s.reportEntriesEvicted(entriesEvicted)
+}
+
+// should be called with a lock.
+func (s *shard[T]) unsafeDelete(key string) {
+	entry := s.entries[key]
+	if entry == nil {
+		return
+	}
+	aliases := s.aliasesByEntry[key]
+	for _, alias := range aliases {
+		delete(s.entriesByAlias, alias)
+	}
+	delete(s.aliasesByEntry, key)
+	delete(s.entries, key)
+}
+
+// look up an entry by key or alias
+// should be called with a lock.
+func (s *shard[T]) unsafeGetByKeyOrAlias(keyOrAlias string) (*entry[T], bool) {
+	// try a direct key lookup first
+	item, ok := s.entries[keyOrAlias]
+	if ok {
+		return item, true
+	}
+
+	// if there is no entry by key, try to find it by alias
+	entryKey := s.entriesByAlias[keyOrAlias]
+	if entryKey == "" {
+		return nil, false
+	}
+	item, ok = s.entries[entryKey]
+	return item, ok
 }
 
 // get retrieves attempts to retrieve a value from the shard.
@@ -93,7 +129,7 @@ func (s *shard[T]) forceEvict() {
 //	refresh: A boolean indicating if the value should be refreshed in the background.
 func (s *shard[T]) get(key string) (val T, exists, markedAsMissing, refresh bool) {
 	s.RLock()
-	item, ok := s.entries[key]
+	item, ok := s.unsafeGetByKeyOrAlias(key)
 	if !ok {
 		s.RUnlock()
 		return val, false, false, false
@@ -133,7 +169,7 @@ func (s *shard[T]) get(key string) (val T, exists, markedAsMissing, refresh bool
 
 // set writes a key-value pair to the shard and returns a
 // boolean indicating whether an eviction was performed.
-func (s *shard[T]) set(key string, value T, isMissingRecord bool) bool {
+func (s *shard[T]) set(key string, value T, isMissingRecord bool, aliases []string) bool {
 	s.Lock()
 	defer s.Unlock()
 
@@ -169,19 +205,33 @@ func (s *shard[T]) set(key string, value T, isMissingRecord bool) bool {
 		newEntry.numOfRefreshRetries = 0
 	}
 
-	s.entries[key] = newEntry
+	s.unsafeUpsert(newEntry, key, aliases)
 	return evict
+}
+
+func (s *shard[T]) unsafeUpsert(newEntry *entry[T], key string, aliases []string) {
+	// if the key already exists, temporarily remove it
+	if _, ok := s.entries[key]; ok {
+		s.unsafeDelete(key)
+	}
+
+	// insert the new entry and aliases
+	s.entries[key] = newEntry
+	for _, alias := range aliases {
+		s.entriesByAlias[alias] = key
+	}
+	s.aliasesByEntry[key] = aliases
 }
 
 // delete removes a key from the shard.
 func (s *shard[T]) delete(key string) {
 	s.Lock()
 	defer s.Unlock()
-	delete(s.entries, key)
+	s.unsafeDelete(key)
 }
 
 // keys returns all non-expired keys in the shard.
-func (s *shard[T]) keys() []string {
+func (s *shard[T]) keys(options ...func(key string) bool) []string {
 	s.RLock()
 	defer s.RUnlock()
 	keys := make([]string, 0, len(s.entries))


### PR DESCRIPTION
This PR adds support for key aliases. Still very WIP as I understand more about how this lib works. You're way ahead of me on how you're thinking about advanced caching issues, so I'm trying to find something that fits. 

I will keep this updated with the latest attempt and change it from draft when I think there is something stable to review.

```go
type TestCacheItem struct {
	sturdyc.ISturdyCItem
	key     string
	aliases []string
}

func NewTestCacheItem(key string, aliases []string) *TestCacheItem {
	return &TestCacheItem{
		key:     key,
		aliases: aliases,
	}
}

func (t *TestCacheItem) GetCacheKey() string {
	return t.key
}

func (t *TestCacheItem) GetCacheAliasKeys() []string {
	return t.aliases
}

client.Set("my_key", NewTestCacheItem("value", []string{"alias1", "alias2"}))
client.Get("my_key")
client.Get("alias1")
client.Get("alias2")
```

### Notes
* Item aliases are tracked by the shard that owns the item
* You could consider soft-deprecating `GetManyKeyFn` and `SetManyKeyFn` since they can be covered by implementing the interface.

### Benchmarks

#### before

```
goos: darwin
goarch: arm64
pkg: github.com/viccon/sturdyc
cpu: Apple M1 Max
BenchmarkGetConcurrent-10        7470562               156.6 ns/op               1.000 hits/op
BenchmarkSetConcurrent-10        7944378               180.2 ns/op               0 evictions/op
```

#### after

*These benchmarks don't test any alias load, just the empty logic*

```
goos: darwin
goarch: arm64
pkg: github.com/viccon/sturdyc
cpu: Apple M1 Max
BenchmarkGetConcurrent-10        7158730               162.0 ns/op               1.000 hits/op
BenchmarkSetConcurrent-10        5167750               281.2 ns/op               0 evictions/op
```
