### PR TITLE
Synchronous early refreshes (WIP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,18 +23,18 @@ _robust_ and _highly performant_.
 The API is very simple to use. If you’re currently retrieving your data from a
 distributed cache, database, or API, you should be able to add this package to
 your application for a significant performance boost without losing data
-freshness -- provided you configure your cache client correctly. As you will
-see below, there are many options, and I encourage you to read through this
-README and experiment with the examples to get an understanding of how it
-works. Below is a screenshot showing the P95 latency improvements we've
-observed after using this package in front of our distributed key-value store:
+freshness — provided you configure your cache client correctly. As you will see
+below, there are many options, and I encourage you to read through this README
+and experiment with the examples to get an understanding of how it works. Below
+is a screenshot showing the P95 latency improvements we've observed after adding
+this package in front of our distributed key-value store:
 
 &nbsp;
 <img width="1554" alt="Screenshot 2024-05-10 at 10 15 18" src="https://github.com/viccon/sturdyc/assets/12787673/adad1d4c-e966-4db1-969a-eda4fd75653a">
 &nbsp;
 
 In addition to this, we were also able to reduce our number of outgoing
-requests by more than 90% after enabling the refresh coalescing option.
+requests by more than 90% after enabling the _refresh coalescing_ option.
 
 # Installing
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ in the sections to follow.
 
 # Evictions
 
-The cache has two eviction strategies. One is a run a background job which
+The cache has two eviction strategies. One is a background job which
 continuously evicts expired records from each shard. However, there are options
 to both tweak the interval at which the job runs:
 
@@ -120,7 +120,7 @@ cacheClient := sturdyc.New[int](capacity, numShards, ttl, evictionPercentage,
 ```
 
 The latter can give you a slight performance boost in situations where you're
-unlikely to ever exceed the capacity of your cache.
+unlikely to ever exceed the capacity you've assigned to your cache.
 
 However, when the cache capacity is reached, the second eviction strategy is
 triggered. This process performs evictions on a per-shard basis, selecting
@@ -133,12 +133,11 @@ Next, we'll start to look at some of the more _advanced features_.
 
 # Get or fetch
 
-I have tried to design the API in a way that should make it effortless to start
-consuming your applications data through `sturdyc`. To take advantage of all
-the more advanced functionality and configurations you'll essentially just be
-interacting with two functions: `GetOrFetch` and `GetOrFetchBatch`.
+The API has been designed to make the process of integrating `sturdyc` with any
+data source as straightforward as possible. The more advanced functionality is
+accessed through just two core functions: `GetOrFetch` and `GetOrFetchBatch`
 
-Let's say that we had the following code for fetching orders:
+As an example, let's say that we had the following code for fetching orders:
 
 ```go
 func (c *Client) Order(ctx context.Context, id string) (Order, error) {

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 high-throughput systems through features such as request coalescing and
 asynchronous refreshes. It combines the speed of in-memory caching with
 granular control over data freshness. At its core, `sturdyc` provides
-**non-blocking reads** and sharded writes for minimal lock contention. The
+**non-blocking reads** and **sharded writes** for minimal lock contention. The
 [xxhash](https://github.com/cespare/xxhash) algorithm is used for efficient key
 distribution.
 
@@ -127,7 +127,7 @@ cacheClient := sturdyc.New[int](capacity, numShards, ttl, evictionPercentage,
 The latter can give you a slight performance boost in situations where you're
 unlikely to ever exceed the capacity you've assigned to your cache.
 
-However, when the cache capacity is reached, the second eviction strategy is
+However, if the cache capacity is reached, the second eviction strategy is
 triggered. This process performs evictions on a per-shard basis, selecting
 records for removal based on recency. The eviction algorithm uses
 [quickselect](https://en.wikipedia.org/wiki/Quickselect), which has an O(N)

--- a/README.md
+++ b/README.md
@@ -1382,21 +1382,21 @@ Another point to note is how effectively the options we've seen so far can be
 combined to create high-performing, flexible, and robust caching solutions:
 
 ```go
-    capacity := 10000
-	numShards := 10
-	ttl := 2 * time.Hour
-	evictionPercentage := 10
-	minRefreshDelay := time.Second
-	maxRefreshDelay := time.Second * 2
-	synchronousRefreshDelay := time.Second * 120 // 2 minutes.
-	retryBaseDelay := time.Millisecond * 10
-	batchSize := 10
-	batchBufferTimeout := time.Second * 15
+capacity := 10000
+numShards := 10
+ttl := 2 * time.Hour
+evictionPercentage := 10
+minRefreshDelay := time.Second
+maxRefreshDelay := time.Second * 2
+synchronousRefreshDelay := time.Second * 120 // 2 minutes.
+retryBaseDelay := time.Millisecond * 10
+batchSize := 10
+batchBufferTimeout := time.Second * 15
 
-	cacheClient := sturdyc.New[string](capacity, numShards, ttl, evictionPercentage,
-		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, synchronousRefreshDelay, retryBaseDelay),
-		sturdyc.WithRefreshCoalescing(batchSize, batchBufferTimeout),
-	)
+cacheClient := sturdyc.New[string](capacity, numShards, ttl, evictionPercentage,
+	sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, synchronousRefreshDelay, retryBaseDelay),
+	sturdyc.WithRefreshCoalescing(batchSize, batchBufferTimeout),
+)
 ```
 
 With the configuration above, the keys in active rotation are going to be

--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ Next, we'll start to look at some of the more _advanced features_.
 
 I have tried to design the API in a way that should make it effortless to add
 `sturdyc` to an existing application. To take advantage of the more advanced
-functionality that we'll see in the sections below you'll essentially just be
-interacting with two functions: `GetOrFetch` and `GetOrFetchBatch`.
+functionality you'll essentially just be interacting with two functions:
+`GetOrFetch` and `GetOrFetchBatch`.
 
 All you would have to do is to take your existing code:
 
@@ -153,7 +153,7 @@ func (c *Client) Order(ctx context.Context, id string) (Order, error) {
 }
 ```
 
-and wrap the actual lines that retrieves the data in a function, and then hand
+and wrap the lines of code that retrieves the data in a function, and then hand
 that over to our cache client:
 
 ```go
@@ -181,8 +181,10 @@ underlying data source.
 
 Most of our examples are going to be retrieving data from HTTP APIs, but it's
 just as easy to wrap a database query, a remote procedure call, a disk read, or
-any other I/O operation. We'll also see how we can use closures to pass query
-parameters and other options.
+any other I/O operation.
+
+We'll also see how we can use closures to pass query parameters and other
+options.
 
 # Stampede protection
 
@@ -253,7 +255,7 @@ returns a map with a numerical value for every ID:
 ```go
 	var count atomic.Int32
 	fetchFn := func(_ context.Context, ids []string) (map[string]int, error) {
-        // Increment the counter so that we can assert how many times this function was called.
+		// Increment the counter so that we can assert how many times this function was called.
 		count.Add(1)
 		time.Sleep(time.Second * 5)
 
@@ -279,9 +281,10 @@ IDs each:
 ```
 
 IDs can often be used to fetch data from multiple data sources. As an example,
-we might use an userId to fetch orders, payments, shipment options, etc. Hence,
-if we're using the cache with an API client, we'll want to prefix this user ID
-with the actual endpoint we're using in order to make the cache key unique.
+we might use an id to fetch a users orders, payments, shipment options, etc.
+Hence, if we're using the cache with an API client, we'll want to prefix this
+user id with the actual endpoint we're consuming in order to make the cache key
+unique.
 
 The package provides more functionality for this that we'll see later on, but
 for now we'll use the most simple version which adds a string prefix to every
@@ -291,7 +294,7 @@ ID:
 	keyPrefixFn := cacheClient.BatchKeyFn("my-data-source")
 ```
 
-This will result in cache keys like this:
+This will result in cache keys of this format:
 
 ```
 my-data-source-ID-1
@@ -309,8 +312,8 @@ We can now request each batch in a separate goroutine:
 		}()
 	}
 
-    // Sleep to give the goroutines above a chance to run.
-    // This ensures that the batches are in-flight.
+	// Sleep to give the goroutines above a chance to run.
+	// This ensures that the batches are in-flight.
 	time.Sleep(time.Second * 3)
 ```
 
@@ -320,11 +323,11 @@ Each goroutine is going to request two random IDs from our batches:
 
 ```go
 	// Launch another 5 goroutines that are going to pick two random IDs from any of our in-flight batches.
-    // e.g:
-    // [1,8]
-    // [4,11]
-    // [14,2]
-    // [6,15]
+	// e.g:
+	// [1,8]
+	// [4,11]
+	// [14,2]
+	// [6,15]
 	var wg sync.WaitGroup
 	for i := 0; i < 5; i++ {
 		wg.Add(1)

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ It has all the functionality you would expect from a caching library, but what
 **sets it apart** are the features designed to make I/O heavy applications both
 _robust_ and _highly performant_.
 
-If you’re currently retrieving your data from a distributed cache, database, or
-API, you could probably consume it through this package for a significant
-performance boost. As you will see below, there are many ways to configure this
-package, and I encourage you to read through this README and experiment with
-the examples to get an understanding of how it works.
+We have been using it in production to enhance both the performance and
+reliability of our services that retrieve data from distributed caches,
+databases, and APIs. While the API surface of this package is tiny, it offers
+extensive configuration options. I encourage you to read through this README
+and experiment with the examples in order to understand its full capabilities.
 
 Here is a screenshot showing the P95 latency improvements we've observed after adding
 this package in front of our distributed key-value store:

--- a/README.md
+++ b/README.md
@@ -37,11 +37,6 @@ this package in front of our distributed key-value store:
 In addition to this, we were also able to reduce our number of outgoing
 requests by more than 90% after enabling the _refresh coalescing_ option.
 
-# Installing
-
-```sh
-go get github.com/viccon/sturdyc
-```
 
 # Table of contents
 
@@ -50,6 +45,7 @@ if this is your first time using this package, I encourage you to **read these
 examples in the order they appear**. Most of them build on each other, and many
 share configurations.
 
+- [**installing**](https://github.com/viccon/sturdyc?tab=readme-ov-file#installing)
 - [**creating a cache client**](https://github.com/viccon/sturdyc?tab=readme-ov-file#creating-a-cache-client)
 - [**evictions**](https://github.com/viccon/sturdyc?tab=readme-ov-file#evictions)
 - [**get or fetch**](https://github.com/viccon/sturdyc?tab=readme-ov-file#get-or-fetch)
@@ -64,6 +60,12 @@ share configurations.
 - [**distributed storage**](https://github.com/viccon/sturdyc?tab=readme-ov-file#distributed-storage)
 - [**custom metrics**](https://github.com/viccon/sturdyc?tab=readme-ov-file#custom-metrics)
 - [**generics**](https://github.com/viccon/sturdyc?tab=readme-ov-file#generics)
+
+# Installing
+
+```sh
+go get github.com/viccon/sturdyc
+```
 
 # Creating a cache client
 
@@ -94,12 +96,30 @@ configuration:
 	log.Println(cacheClient.Get("key1"))
 ```
 
+We're also able to provide a vast set of additional options which we are going
+to explore in the sections below.
+
 # Evictions
 
 The cache runs a background job which continuously evicts expired records from
-each shard. However, there are options to both tweak the interval and disable
-the functionality altogether. This is can give you a slight performance boost
-in situations where you're unlikely to exceed any memory limits.
+each shard. However, there are options to both tweak the interval:
+
+```go
+	cacheClient := sturdyc.New[int](capacity, numShards, ttl, evictionPercentage,
+		sturdyc.WithEvictionInterval(time.Second),
+	)
+```
+
+and disable the functionality altogether:
+
+```go
+	cacheClient := sturdyc.New[int](capacity, numShards, ttl, evictionPercentage,
+		sturdyc.WithNoContinuousEvictions()
+	)
+```
+
+The latter can give you a slight performance boost in situations where you're
+unlikely to exceed any memory limits..
 
 When the cache reaches its capacity, a fallback eviction is triggered. This
 process performs evictions on a per-shard basis, selecting records for removal

--- a/README.md
+++ b/README.md
@@ -23,9 +23,18 @@ _robust_ and _highly performant_.
 The API is very simple to use. If you’re currently retrieving your data from a
 distributed cache, database, or API, you should be able to add this package to
 your application for a significant performance boost without losing data
-freshness -- provided you configure your cache client correctly. As you will see
-below, there are many options, and I encourage you to read through this README
-and experiment with the examples.
+freshness -- provided you configure your cache client correctly. As you will
+see below, there are many options, and I encourage you to read through this
+README and experiment with the examples to get an understanding of how it
+works. Below is a screenshot showing the P95 latency improvements we've
+observed after using this package in front of our distributed key-value store:
+
+&nbsp;
+<img width="1554" alt="Screenshot 2024-05-10 at 10 15 18" src="https://github.com/viccon/sturdyc/assets/12787673/adad1d4c-e966-4db1-969a-eda4fd75653a">
+&nbsp;
+
+In addition to this, we were also able to reduce our number of outgoing
+requests by more than 90% after enabling the refresh coalescing option.
 
 # Installing
 
@@ -89,18 +98,6 @@ based on recency. The eviction algorithm uses
 [quickselect](https://en.wikipedia.org/wiki/Quickselect), which has an O(N)
 time complexity without requiring write locks on reads to update a recency
 list.
-
-### Latency improvements
-
-Below is a screenshot showing the latency improvements we've observed after
-replacing our old cache with this package:
-
-&nbsp;
-<img width="1554" alt="Screenshot 2024-05-10 at 10 15 18" src="https://github.com/viccon/sturdyc/assets/12787673/adad1d4c-e966-4db1-969a-eda4fd75653a">
-&nbsp;
-
-In addition to this, we've seen our number of outgoing requests decrease by
-more than 90% after enabling refresh coalescing.
 
 # Adding `sturdyc` to your application:
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![sturdyC-fn-2](https://github.com/user-attachments/assets/2def120a-ad2b-4590-bef0-83c461af1b07)
-> A sturdy gopher shielding data sources from rapidly incoming requests
+> A sturdy gopher shielding data sources from rapidly incoming requests.
 
 # `sturdyc`: a caching library for building sturdy systems
 

--- a/README.md
+++ b/README.md
@@ -1570,7 +1570,7 @@ All you have to do is implement one of these interfaces:
 type MetricsRecorder interface {
 	CacheHit()
 	CacheMiss()
-	BackgroundRefresh()
+	AsynchronousRefresh()
 	SynchronousRefresh()
 	MissingRecord()
 	ForcedEviction()

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ It has all the functionality you would expect from a caching library, but what
 _robust_ and _highly performant_.
 
 If you’re currently retrieving your data from a distributed cache, database, or
-API, you should be able to add this package to your application for a
-significant performance boost. As you will see below, there are many options,
-and I encourage you to read through this README and experiment with the
-examples to get an understanding of how it works.
+API, you're probably able to add this package to your application for a
+significant performance boost. As you will see below, there are many ways to
+configure this package, and I encourage you to read through this README and
+experiment with the examples to get an understanding of how it works.
 
 Here is a screenshot showing the P95 latency improvements we've observed after adding
 this package in front of our distributed key-value store:

--- a/README.md
+++ b/README.md
@@ -476,13 +476,21 @@ chosen to refresh the value won’t retrieve the updated data right away as the
 refresh happens asynchronously.
 
 However, asynchronous refreshes present challenges with infrequently requested
-keys. When the refreshes are done in the background the latency will be low,
-but the data might feel flaky or stale if we're not asking for the key again
-soon after so that it is being continuously refreshed.
+keys. While background refreshes keep latency low by serving cached values
+during updates, this can lead to perpetually stale data. If a key isn't
+requested again before its next scheduled refresh, we remain permanently one
+update behind, as each read triggers a refresh that won't be seen until the
+next request. This is similar to a burger restaurant that prepares a new burger
+after each customer's order - if the next customer arrives too late, they'll
+receive a cold burger, despite the restaurant's proactive cooking strategy.
 
 To solve this, you also get to provide a synchronous refresh time. This
 essentially tells the cache: "If the data is older than x, I want the refresh
-to be blocking and have the user wait for the response."
+to be blocking and have the user wait for the response." Or using the burger
+analogy: if a burger has been sitting for more than X minutes, the restaurant
+starts making a fresh one while the customer waits. Unlike a real restaurant
+though, the cache keeps the old value as a fallback - if the refresh fails,
+we'll still serve the "cold burger" rather than letting the customer go hungry.
 
 Below is an example configuration that you can use to enable this
 functionality:

--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ It has all the functionality you would expect from a caching library, but what
 **sets it apart** are the features designed to make I/O heavy applications both
 _robust_ and _highly performant_.
 
+The API is very simple to use. If you’re currently retrieving your data from a
+distributed cache, database, or API, you should be able to add this package to
+your application for a significant performance boost without losing data
+freshness -- provided you configure your cache client correctly. As you will see
+below, there are many options, and I encourage you to read through this README
+and experiment with the examples.
+
 # Installing
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ![sturdyC-fn-2](https://github.com/user-attachments/assets/2def120a-ad2b-4590-bef0-83c461af1b07)
+> *A sturdy gopher shielding data sources from rapidly incoming requests
 
 # `sturdyc`: a caching library for building sturdy systems
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ this package in front of our distributed key-value store:
 &nbsp;
 
 In addition to this, we were also able to reduce our number of outgoing
-requests by more than 90% after enabling the _refresh coalescing_ option.
-
+requests by more than 90% after enabling the _refresh coalescing_ functionality.
 
 # Table of contents
 
@@ -72,31 +71,32 @@ The first thing you will have to do is to create a cache client to hold your
 configuration:
 
 ```go
-	// Maximum number of entries in the cache. Exceeding this number will trigger
-	// an eviction (as long as the "evictionPercentage" is greater than 0).
-	capacity := 10000
-	// Number of shards to use. Increasing this number will reduce write lock collisions.
-	numShards := 10
-	// Time-to-live for cache entries.
-	ttl := 2 * time.Hour
-	// Percentage of entries to evict when the cache reaches its capacity. Setting this
-	// to 0 will make writes a no-op until an item has either expired or been deleted.
-	evictionPercentage := 10
+// Maximum number of entries in the cache. Exceeding this number will trigger
+// an eviction (as long as the "evictionPercentage" is greater than 0).
+capacity := 10000
+// Number of shards to use. Increasing this number will reduce write lock collisions.
+numShards := 10
+// Time-to-live for cache entries.
+ttl := 2 * time.Hour
+// Percentage of entries to evict when the cache reaches its capacity. Setting this
+// to 0 will make writes a no-op until an item has either expired or been deleted.
+evictionPercentage := 10
 
-	// Create a cache client with the specified configuration.
-	cacheClient := sturdyc.New[int](capacity, numShards, ttl, evictionPercentage)
+// Create a cache client with the specified configuration.
+cacheClient := sturdyc.New[int](capacity, numShards, ttl, evictionPercentage)
 
-	cacheClient.Set("key1", 99)
-	log.Println(cacheClient.Size())
-	log.Println(cacheClient.Get("key1"))
+cacheClient.Set("key1", 99)
+log.Println(cacheClient.Size())
+log.Println(cacheClient.Get("key1"))
 
-	cacheClient.Delete("key1")
-	log.Println(cacheClient.Size())
-	log.Println(cacheClient.Get("key1"))
+cacheClient.Delete("key1")
+log.Println(cacheClient.Size())
+log.Println(cacheClient.Get("key1"))
 ```
 
-We're also able to provide a vast set of additional options which we are going
-to explore in the sections below.
+As the final argument to the `New` function, we're also able to provide a wide
+range of additional options, which we will explore in detail in the sections
+to follow.
 
 # Evictions
 
@@ -104,21 +104,21 @@ The cache runs a background job which continuously evicts expired records from
 each shard. However, there are options to both tweak the interval:
 
 ```go
-	cacheClient := sturdyc.New[int](capacity, numShards, ttl, evictionPercentage,
-		sturdyc.WithEvictionInterval(time.Second),
-	)
+cacheClient := sturdyc.New[int](capacity, numShards, ttl, evictionPercentage,
+    sturdyc.WithEvictionInterval(time.Second),
+)
 ```
 
 and disable the functionality altogether:
 
 ```go
-	cacheClient := sturdyc.New[int](capacity, numShards, ttl, evictionPercentage,
-		sturdyc.WithNoContinuousEvictions()
-	)
+cacheClient := sturdyc.New[int](capacity, numShards, ttl, evictionPercentage,
+    sturdyc.WithNoContinuousEvictions()
+)
 ```
 
 The latter can give you a slight performance boost in situations where you're
-unlikely to exceed any memory limits..
+unlikely to exceed any memory limits.
 
 When the cache reaches its capacity, a fallback eviction is triggered. This
 process performs evictions on a per-shard basis, selecting records for removal

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![sturdyC-fn-2](https://github.com/user-attachments/assets/2def120a-ad2b-4590-bef0-83c461af1b07)
-> *A sturdy gopher shielding data sources from rapidly incoming requests
+> A sturdy gopher shielding data sources from rapidly incoming requests
 
 # `sturdyc`: a caching library for building sturdy systems
 

--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ It has all the functionality you would expect from a caching library, but what
 **sets it apart** are the features designed to make I/O heavy applications both
 _robust_ and _highly performant_.
 
-We have been using it in production to enhance both the performance and
-reliability of our services that retrieve data from distributed caches,
-databases, and APIs. While the API surface of this package is tiny, it offers
+We have been using this package in production to enhance both the performance
+and reliability of our services that retrieve data from distributed caches,
+databases, and APIs. While the API surface of sturdyc is tiny, it offers
 extensive configuration options. I encourage you to read through this README
-and experiment with the examples in order to understand its full capabilities.
+and experiment with the examples to understand its full capabilities.
 
-Here is a screenshot showing the P95 latency improvements we've observed after adding
-this package in front of our distributed key-value store:
+Here is a screenshot showing the P95 latency improvements we observed after
+adding this package in front of a distributed key-value store:
 
 &nbsp;
 <img width="1554" alt="Screenshot 2024-05-10 at 10 15 18" src="https://github.com/viccon/sturdyc/assets/12787673/adad1d4c-e966-4db1-969a-eda4fd75653a">
@@ -94,9 +94,10 @@ log.Println(cacheClient.Size())
 log.Println(cacheClient.Get("key1"))
 ```
 
-As the final argument to the `New` function, we're also able to provide a large
-number of additional options, which we will explore in detail in the sections
-to follow.
+
+The `New` function is variadic, and as the final argument we're also able to
+provide a wide range of configuration options, which we will explore in detail
+in the sections to follow.
 
 # Evictions
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,10 @@ adding this package in front of a distributed key-value store:
 <img width="1554" alt="Screenshot 2024-05-10 at 10 15 18" src="https://github.com/viccon/sturdyc/assets/12787673/adad1d4c-e966-4db1-969a-eda4fd75653a">
 &nbsp;
 
-In addition to this, we were also able to reduce our number of outgoing
-requests by more than 90% after enabling the _refresh coalescing_ functionality.
+In addition to this, we were able to reduce our outgoing requests by more than
+90% after utilizing both the in-flight tracking of cache keys and refresh
+coalescing functionality, which in turn has allowed us to use fewer containers
+and much cheaper clusters.
 
 # Table of contents
 

--- a/README.md
+++ b/README.md
@@ -20,12 +20,11 @@ It has all the functionality you would expect from a caching library, but what
 **sets it apart** are the features designed to make I/O heavy applications both
 _robust_ and _highly performant_.
 
-The API is very simple to use. If you’re currently retrieving your data from a
-distributed cache, database, or API, you should be able to add this package to
-your application for a significant performance boost without losing data
-freshness — provided you configure your cache client correctly. As you will see
-below, there are many options, and I encourage you to read through this README
-and experiment with the examples to get an understanding of how it works.
+If you’re currently retrieving your data from a distributed cache, database, or
+API, you should be able to add this package to your application for a
+significant performance boost. As you will see below, there are many options,
+and I encourage you to read through this README and experiment with the
+examples to get an understanding of how it works.
 
 Here is a screenshot showing the P95 latency improvements we've observed after adding
 this package in front of our distributed key-value store:

--- a/buffer_test.go
+++ b/buffer_test.go
@@ -20,6 +20,7 @@ func TestBatchIsRefreshedWhenTheTimeoutExpires(t *testing.T) {
 	evictionPercentage := 10
 	minRefreshDelay := time.Minute * 5
 	maxRefreshDelay := time.Minute * 10
+	synchronousRefreshDelay := time.Minute * 30
 	refreshRetryInterval := time.Millisecond * 10
 	batchSize := 10
 	batchBufferTimeout := time.Minute
@@ -34,7 +35,7 @@ func TestBatchIsRefreshedWhenTheTimeoutExpires(t *testing.T) {
 	//    2. The 'batchBufferTimeout' threshold is exceeded.
 	client := sturdyc.New[string](capacity, numShards, ttl, evictionPercentage,
 		sturdyc.WithNoContinuousEvictions(),
-		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, refreshRetryInterval),
+		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, synchronousRefreshDelay, refreshRetryInterval),
 		sturdyc.WithMissingRecordStorage(),
 		sturdyc.WithRefreshCoalescing(batchSize, batchBufferTimeout),
 		sturdyc.WithClock(clock),
@@ -86,6 +87,7 @@ func TestBatchIsRefreshedWhenTheBufferSizeIsReached(t *testing.T) {
 	ttl := time.Hour
 	minRefreshDelay := time.Minute * 5
 	maxRefreshDelay := time.Minute * 10
+	synchronousRefreshDelay := time.Minute * 30
 	refreshRetryInterval := time.Millisecond * 10
 	batchSize := 10
 	batchBufferTimeout := time.Minute
@@ -100,7 +102,7 @@ func TestBatchIsRefreshedWhenTheBufferSizeIsReached(t *testing.T) {
 	//    2. The 'batchBufferTimeout' threshold is exceeded.
 	client := sturdyc.New[string](capacity, numShards, ttl, evictionPercentage,
 		sturdyc.WithNoContinuousEvictions(),
-		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, refreshRetryInterval),
+		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, synchronousRefreshDelay, refreshRetryInterval),
 		sturdyc.WithMissingRecordStorage(),
 		sturdyc.WithRefreshCoalescing(batchSize, batchBufferTimeout),
 		sturdyc.WithClock(clock),
@@ -180,6 +182,7 @@ func TestBatchIsNotRefreshedByDuplicates(t *testing.T) {
 	evictionPercentage := 10
 	minRefreshDelay := time.Minute * 5
 	maxRefreshDelay := time.Minute * 10
+	synchronousRefreshDelay := time.Minute * 30
 	refreshRetryInterval := time.Millisecond * 10
 	batchSize := 10
 	batchBufferTimeout := time.Minute
@@ -194,7 +197,7 @@ func TestBatchIsNotRefreshedByDuplicates(t *testing.T) {
 	//    2. The 'batchBufferTimeout' threshold is exceeded.
 	client := sturdyc.New[string](capacity, numShards, ttl, evictionPercentage,
 		sturdyc.WithNoContinuousEvictions(),
-		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, refreshRetryInterval),
+		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, synchronousRefreshDelay, refreshRetryInterval),
 		sturdyc.WithMissingRecordStorage(),
 		sturdyc.WithRefreshCoalescing(batchSize, batchBufferTimeout),
 		sturdyc.WithClock(clock),
@@ -250,6 +253,7 @@ func TestBatchesAreGroupedByPermutations(t *testing.T) {
 	evictionPercentage := 15
 	minRefreshDelay := time.Minute * 5
 	maxRefreshDelay := time.Minute * 10
+	synchronousRefreshDelay := time.Minute * 30
 	refreshRetryInterval := time.Millisecond * 10
 	batchSize := 5
 	batchBufferTimeout := time.Minute
@@ -264,7 +268,7 @@ func TestBatchesAreGroupedByPermutations(t *testing.T) {
 	//    2. The 'batchBufferTimeout' threshold is exceeded.
 	c := sturdyc.New[any](capacity, numShards, ttl, evictionPercentage,
 		sturdyc.WithNoContinuousEvictions(),
-		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, refreshRetryInterval),
+		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, synchronousRefreshDelay, refreshRetryInterval),
 		sturdyc.WithMissingRecordStorage(),
 		sturdyc.WithRefreshCoalescing(batchSize, batchBufferTimeout),
 		sturdyc.WithClock(clock),
@@ -339,6 +343,7 @@ func TestLargeBatchesAreChunkedCorrectly(t *testing.T) {
 	evictionPercentage := 23
 	minRefreshDelay := time.Minute * 5
 	maxRefreshDelay := time.Minute * 10
+	synchronousRefreshDelay := time.Minute * 30
 	refreshRetryInterval := time.Millisecond * 10
 	batchSize := 5
 	batchBufferTimeout := time.Minute
@@ -353,7 +358,7 @@ func TestLargeBatchesAreChunkedCorrectly(t *testing.T) {
 	//    2. The 'batchBufferTimeout' threshold is exceeded.
 	client := sturdyc.New[string](capacity, numShards, ttl, evictionPercentage,
 		sturdyc.WithNoContinuousEvictions(),
-		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, refreshRetryInterval),
+		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, synchronousRefreshDelay, refreshRetryInterval),
 		sturdyc.WithMissingRecordStorage(),
 		sturdyc.WithRefreshCoalescing(batchSize, batchBufferTimeout),
 		sturdyc.WithClock(clock),
@@ -401,6 +406,7 @@ func TestValuesAreUpdatedCorrectly(t *testing.T) {
 	evictionPercentage := 10
 	minRefreshDelay := time.Minute * 5
 	maxRefreshDelay := time.Minute * 10
+	synchronousRefreshDelay := time.Minute * 50
 	refreshRetryInterval := time.Millisecond * 10
 	batchSize := 10
 	batchBufferTimeout := time.Minute
@@ -415,7 +421,7 @@ func TestValuesAreUpdatedCorrectly(t *testing.T) {
 	//    2. The 'batchBufferTimeout' threshold is exceeded.
 	client := sturdyc.New[any](capacity, numShards, ttl, evictionPercentage,
 		sturdyc.WithNoContinuousEvictions(),
-		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, refreshRetryInterval),
+		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, synchronousRefreshDelay, refreshRetryInterval),
 		sturdyc.WithMissingRecordStorage(),
 		sturdyc.WithRefreshCoalescing(batchSize, batchBufferTimeout),
 		sturdyc.WithClock(clock),

--- a/cache.go
+++ b/cache.go
@@ -29,12 +29,12 @@ type Config struct {
 	metricsRecorder            DistributedMetricsRecorder
 	log                        Logger
 
-	earlyRefreshes         bool
-	minAsyncRefreshTime         time.Duration
-	maxAsyncRefreshTime         time.Duration
-	syncRefreshTime time.Duration
-	retryBaseDelay         time.Duration
-	storeMissingRecords    bool
+	earlyRefreshes      bool
+	minAsyncRefreshTime time.Duration
+	maxAsyncRefreshTime time.Duration
+	syncRefreshTime     time.Duration
+	retryBaseDelay      time.Duration
+	storeMissingRecords bool
 
 	bufferRefreshes      bool
 	batchMutex           sync.Mutex

--- a/cache.go
+++ b/cache.go
@@ -29,11 +29,12 @@ type Config struct {
 	metricsRecorder            DistributedMetricsRecorder
 	log                        Logger
 
-	refreshInBackground bool
-	minRefreshTime      time.Duration
-	maxRefreshTime      time.Duration
-	retryBaseDelay      time.Duration
-	storeMissingRecords bool
+	earlyRefreshes         bool
+	minRefreshTime         time.Duration
+	maxRefreshTime         time.Duration
+	synchronousRefreshTime time.Duration
+	retryBaseDelay         time.Duration
+	storeMissingRecords    bool
 
 	bufferRefreshes      bool
 	batchMutex           sync.Mutex
@@ -127,11 +128,11 @@ func (c *Client[T]) getShard(key string) *shard[T] {
 // getWithState retrieves a single value from the cache and returns additional
 // information about the state of the record. The state includes whether the record
 // exists, if it has been marked as missing, and if it is due for a refresh.
-func (c *Client[T]) getWithState(key string) (value T, exists, markedAsMissing, refresh bool) {
+func (c *Client[T]) getWithState(key string) (value T, exists, markedAsMissing, backgroundRefresh, synchronousRefresh bool) {
 	shard := c.getShard(key)
-	val, exists, markedAsMissing, refresh := shard.get(key)
-	c.reportCacheHits(exists, markedAsMissing, refresh)
-	return val, exists, markedAsMissing, refresh
+	val, exists, markedAsMissing, backgroundRefresh, synchronousRefresh := shard.get(key)
+	c.reportCacheHits(exists, markedAsMissing, backgroundRefresh, synchronousRefresh)
+	return val, exists, markedAsMissing, backgroundRefresh, synchronousRefresh
 }
 
 // Get retrieves a single value from the cache.
@@ -145,8 +146,8 @@ func (c *Client[T]) getWithState(key string) (value T, exists, markedAsMissing, 
 //	The value corresponding to the key and a boolean indicating if the value was found.
 func (c *Client[T]) Get(key string) (T, bool) {
 	shard := c.getShard(key)
-	val, ok, markedAsMissing, refresh := shard.get(key)
-	c.reportCacheHits(ok, markedAsMissing, refresh)
+	val, ok, markedAsMissing, backgroundRefresh, synchronousRefresh := shard.get(key)
+	c.reportCacheHits(ok, markedAsMissing, backgroundRefresh, synchronousRefresh)
 	return val, ok && !markedAsMissing
 }
 

--- a/cache.go
+++ b/cache.go
@@ -30,9 +30,9 @@ type Config struct {
 	log                        Logger
 
 	earlyRefreshes         bool
-	minRefreshTime         time.Duration
-	maxRefreshTime         time.Duration
-	synchronousRefreshTime time.Duration
+	minAsyncRefreshTime         time.Duration
+	maxAsyncRefreshTime         time.Duration
+	syncRefreshTime time.Duration
 	retryBaseDelay         time.Duration
 	storeMissingRecords    bool
 

--- a/distribution_test.go
+++ b/distribution_test.go
@@ -156,7 +156,7 @@ func TestDistributedStorage(t *testing.T) {
 	fetchObserver.AssertFetchCount(t, 1)
 	fetchObserver.Clear()
 
-	// The keys are written asynchonously to the distributed storage.
+	// The keys are written asynchronously to the distributed storage.
 	time.Sleep(100 * time.Millisecond)
 	distributedStorage.assertRecord(t, key)
 	distributedStorage.assertGetCount(t, 1)
@@ -177,7 +177,7 @@ func TestDistributedStorage(t *testing.T) {
 		t.Errorf("expected valuekey1, got %s", res)
 	}
 
-	// The keys are written asynchonously to the distributed storage.
+	// The keys are written asynchronously to the distributed storage.
 	time.Sleep(100 * time.Millisecond)
 	fetchObserver.AssertFetchCount(t, 1)
 	distributedStorage.assertGetCount(t, 2)
@@ -411,7 +411,7 @@ func TestDistributedStorageBatch(t *testing.T) {
 	fetchObserver.AssertFetchCount(t, 1)
 	fetchObserver.Clear()
 
-	// The keys are written asynchonously to the distributed storage.
+	// The keys are written asynchronously to the distributed storage.
 	time.Sleep(100 * time.Millisecond)
 	distributedStorage.assertRecords(t, firstBatchOfIDs, keyFn)
 	distributedStorage.assertGetCount(t, 1)
@@ -444,7 +444,7 @@ func TestDistributedStorageBatch(t *testing.T) {
 	fetchObserver.AssertRequestedRecords(t, []string{"4", "5", "6"})
 	fetchObserver.AssertFetchCount(t, 2)
 
-	// The keys are written asynchonously to the distributed storage.
+	// The keys are written asynchronously to the distributed storage.
 	time.Sleep(100 * time.Millisecond)
 	distributedStorage.assertRecords(t, secondBatchOfIDs, keyFn)
 	distributedStorage.assertGetCount(t, 2)
@@ -480,7 +480,7 @@ func TestDistributedStaleStorageBatch(t *testing.T) {
 	fetchObserver.AssertFetchCount(t, 1)
 	fetchObserver.Clear()
 
-	// The keys are written asynchonously to the distributed storage.
+	// The keys are written asynchronously to the distributed storage.
 	time.Sleep(100 * time.Millisecond)
 	distributedStorage.assertRecords(t, firstBatchOfIDs, keyFn)
 	distributedStorage.assertGetCount(t, 1)
@@ -546,7 +546,7 @@ func TestDistributedStorageBatchDeletes(t *testing.T) {
 	fetchObserver.AssertFetchCount(t, 1)
 	fetchObserver.Clear()
 
-	// The keys are written asynchonously to the distributed storage.
+	// The keys are written asynchronously to the distributed storage.
 	time.Sleep(100 * time.Millisecond)
 	distributedStorage.assertRecords(t, batchOfIDs, keyFn)
 	distributedStorage.assertGetCount(t, 1)
@@ -578,7 +578,7 @@ func TestDistributedStorageBatchDeletes(t *testing.T) {
 	fetchObserver.AssertRequestedRecords(t, batchOfIDs)
 	fetchObserver.AssertFetchCount(t, 2)
 
-	// The keys are written asynchonously to the distributed storage.
+	// The keys are written asynchronously to the distributed storage.
 	time.Sleep(100 * time.Millisecond)
 	distributedStorage.assertRecords(t, []string{"1", "2"}, keyFn)
 	distributedStorage.assertGetCount(t, 2)
@@ -615,7 +615,7 @@ func TestDistributedStorageBatchConvertsToMissingRecord(t *testing.T) {
 	fetchObserver.AssertFetchCount(t, 1)
 	fetchObserver.Clear()
 
-	// The keys are written asynchonously to the distributed storage.
+	// The keys are written asynchronously to the distributed storage.
 	time.Sleep(100 * time.Millisecond)
 	distributedStorage.assertRecords(t, batchOfIDs, keyFn)
 	distributedStorage.assertGetCount(t, 1)
@@ -648,7 +648,7 @@ func TestDistributedStorageBatchConvertsToMissingRecord(t *testing.T) {
 	fetchObserver.AssertFetchCount(t, 2)
 	fetchObserver.Clear()
 
-	// The keys are written asynchonously to the distributed storage.
+	// The keys are written asynchronously to the distributed storage.
 	time.Sleep(100 * time.Millisecond)
 	distributedStorage.assertRecords(t, []string{"1", "2"}, keyFn)
 	distributedStorage.assertGetCount(t, 2)
@@ -675,7 +675,8 @@ func TestDistributedStorageBatchConvertsToMissingRecord(t *testing.T) {
 	fetchObserver.AssertRequestedRecords(t, batchOfIDs)
 	fetchObserver.AssertFetchCount(t, 3)
 
-	// The keys are written asynchonously to the distributed storage.
+	// The keys are written asynchronously to the distributed storage.
+	time.Sleep(100 * time.Millisecond)
 	time.Sleep(100 * time.Millisecond)
 	distributedStorage.assertRecords(t, batchOfIDs, keyFn)
 	distributedStorage.assertGetCount(t, 3)
@@ -727,7 +728,7 @@ func TestDistributedStorageDoesNotCachePartialResponseAsMissingRecords(t *testin
 	fetchObserver.AssertFetchCount(t, 1)
 	fetchObserver.Clear()
 
-	// The keys are written asynchonously to the distributed storage.
+	// The keys are written asynchronously to the distributed storage.
 	time.Sleep(100 * time.Millisecond)
 	distributedStorage.assertRecords(t, batchOfIDs, keyFn)
 	distributedStorage.assertGetCount(t, 1)
@@ -817,7 +818,7 @@ func TestPartialResponseForRefreshesDoesNotResultInMissingRecords(t *testing.T) 
 	fetchObserver.AssertRequestedRecords(t, ids)
 	fetchObserver.Clear()
 
-	// We need to add a sleep because the keys are written asynchonously to the
+	// We need to add a sleep because the keys are written asynchronously to the
 	// distributed storage. We expect that the distributed storage was queried
 	// for the ids before we went to the underlying data source, and then written
 	// to when it resulted in a cache miss and the data was in fact fetched.

--- a/distribution_test.go
+++ b/distribution_test.go
@@ -779,6 +779,7 @@ func TestPartialResponseForRefreshesDoesNotResultInMissingRecords(t *testing.T) 
 	ttl := time.Hour
 	minRefreshDelay := time.Minute * 5
 	maxRefreshDelay := time.Minute * 10
+	synchronousRefreshDelay := time.Minute * 30
 	refreshRetryInterval := time.Millisecond * 10
 	batchSize := 10
 	batchBufferTimeout := time.Minute
@@ -788,7 +789,7 @@ func TestPartialResponseForRefreshesDoesNotResultInMissingRecords(t *testing.T) 
 
 	c := sturdyc.New[string](capacity, numShards, ttl, evictionPercentage,
 		sturdyc.WithNoContinuousEvictions(),
-		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, refreshRetryInterval),
+		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, synchronousRefreshDelay, refreshRetryInterval),
 		sturdyc.WithMissingRecordStorage(),
 		sturdyc.WithRefreshCoalescing(batchSize, batchBufferTimeout),
 		sturdyc.WithDistributedStorageEarlyRefreshes(distributedStorage, refreshAfter),

--- a/errors.go
+++ b/errors.go
@@ -20,10 +20,14 @@ var (
 	// ErrMissingRecord is returned by client.GetOrFetch and client.Passthrough when a record has been marked
 	// as missing. The cache will still try to refresh the record in the background if it's being requested.
 	ErrMissingRecord = errors.New("sturdyc: the record has been marked as missing in the cache")
-	// ErrOnlyCachedRecords is returned by client.GetOrFetchBatch and client.PassthroughBatch
-	// when some of the requested records are available in the cache, but the attempt to
-	// fetch the remaining records failed. As the consumer, you can then decide whether to
-	// proceed with the cached records or if the entire batch is necessary.
+	// ErrOnlyCachedRecords is returned by client.GetOrFetchBatch and
+	// client.PassthroughBatch when some of the requested records are available
+	// in the cache, but the attempt to fetch the remaining records failed. It
+	// may also be returned when you're using the WithEarlyRefreshes
+	// functionality, and the call to synchronously refresh a record failed. The
+	// cache will then give you the latest data it has cached, and you as the
+	// consumer can then decide whether to proceed with the cached records or if
+	// the newest data is necessary.
 	ErrOnlyCachedRecords = errors.New("sturdyc: failed to fetch the records that were not in the cache")
 	// ErrInvalidType is returned when you try to use one of the generic
 	// package level functions but the type assertion fails.

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -60,8 +60,10 @@ func demonstrateGetOrFetchBatch(cacheClient *sturdyc.Client[int]) {
 		{"11", "12", "13", "14", "15"},
 	}
 
-	// We'll use a cache key function to add a prefix to the IDs. If we only used
-	// the IDs, we wouldn't be able to fetch the same IDs from multiple data sources.
+	// We are going to pass a cache a key function that prefixes each id with
+	// the string "my-data-source", and adds an -ID- separator before the actual
+	// id. This makes it possible to save the same id for different data
+	// sources as the keys would look something like this: my-data-source-ID-1
 	keyPrefixFn := cacheClient.BatchKeyFn("my-data-source")
 
 	// Request the keys  for each batch.

--- a/examples/batch/main.go
+++ b/examples/batch/main.go
@@ -54,12 +54,14 @@ func main() {
 	// used to spread out the refreshes for entries evenly over time.
 	minRefreshDelay := time.Second
 	maxRefreshDelay := time.Second * 2
+	// Set a synchronous refresh delay for when we want a refresh to happen synchronously.
+	synchronousRefreshDelay := time.Second * 30
 	// The base for exponential backoff when retrying a refresh.
 	retryBaseDelay := time.Millisecond * 10
 
 	// Create a cache client with the specified configuration.
 	cacheClient := sturdyc.New[string](capacity, numShards, ttl, evictionPercentage,
-		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, retryBaseDelay),
+		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, synchronousRefreshDelay, retryBaseDelay),
 	)
 
 	// Create a new API instance with the cache client.

--- a/examples/batch/main.go
+++ b/examples/batch/main.go
@@ -20,8 +20,10 @@ func NewAPI(c *sturdyc.Client[string]) *API {
 }
 
 func (a *API) GetBatch(ctx context.Context, ids []string) (map[string]string, error) {
-	// We are going to pass the cache a key function that prefixes each id.
-	// This makes it possible to save the same id for different data sources.
+	// We are going to pass a cache a key function that prefixes each id with
+	// the string "some-prefix", and adds an -ID- separator before the actual
+	// id. This makes it possible to save the same id for different data
+	// sources as the keys would look something like this: some-prefix-ID-1
 	cacheKeyFn := a.BatchKeyFn("some-prefix")
 
 	// The fetchFn is only going to retrieve the IDs that are not in the cache.

--- a/examples/buffering/main.go
+++ b/examples/buffering/main.go
@@ -23,7 +23,7 @@ func NewOrderAPI(client *sturdyc.Client[string]) *OrderAPI {
 }
 
 func (a *OrderAPI) OrderStatus(ctx context.Context, ids []string, opts OrderOptions) (map[string]string, error) {
-	// We use the  PermutedBatchKeyFn when an ID isn't enough to uniquely identify a
+	// We use the PermutedBatchKeyFn when an ID isn't enough to uniquely identify a
 	// record. The cache is going to store each id once per set of options. In a more
 	// realistic scenario, the opts would be query params or arguments to a DB query.
 	cacheKeyFn := a.PermutatedBatchKeyFn("key", opts)

--- a/examples/buffering/main.go
+++ b/examples/buffering/main.go
@@ -56,6 +56,8 @@ func main() {
 	// used to spread out the refreshes for entries evenly over time.
 	minRefreshDelay := time.Second
 	maxRefreshDelay := time.Second * 2
+	// Set a synchronous refresh delay for when we want a refresh to happen synchronously.
+	synchronousRefreshDelay := time.Second * 30
 	// The base for exponential backoff when retrying a refresh.
 	retryBaseDelay := time.Millisecond * 10
 	// Whether to store misses in the sturdyc. This can be useful to
@@ -68,7 +70,7 @@ func main() {
 
 	// Create a new cache client with the specified configuration.
 	cacheClient := sturdyc.New[string](capacity, numShards, ttl, evictionPercentage,
-		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, retryBaseDelay),
+		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, synchronousRefreshDelay, retryBaseDelay),
 		sturdyc.WithRefreshCoalescing(batchSize, batchBufferTimeout),
 	)
 

--- a/examples/distributed-early-refreshes/client.go
+++ b/examples/distributed-early-refreshes/client.go
@@ -19,9 +19,10 @@ const (
 
 // Configuration for the early in-memory refreshes.
 const (
-	minRefreshTime = 2 * time.Second
-	maxRefreshTime = 4 * time.Second
-	retryBaseDelay = 5 * time.Second
+	minRefreshTime         = 2 * time.Second
+	maxRefreshTime         = 4 * time.Second
+	synchronousRefreshTime = 30 * time.Second
+	retryBaseDelay         = 5 * time.Second
 )
 
 // Configuration for the refresh coalescing.
@@ -36,7 +37,7 @@ const refreshAfter = time.Second
 func newAPIClient(distributedStorage sturdyc.DistributedStorageWithDeletions) *apiClient {
 	return &apiClient{
 		cache: sturdyc.New[any](capacity, numberOfShards, ttl, percentageOfRecordsToEvictWhenFull,
-			sturdyc.WithEarlyRefreshes(minRefreshTime, maxRefreshTime, retryBaseDelay),
+			sturdyc.WithEarlyRefreshes(minRefreshTime, maxRefreshTime, synchronousRefreshTime, retryBaseDelay),
 			sturdyc.WithRefreshCoalescing(idealBufferSize, bufferTimeout),
 			sturdyc.WithDistributedStorageEarlyRefreshes(distributedStorage, refreshAfter),
 			// NOTE: Uncommenting this line will make the cache mark the records as

--- a/examples/distribution/client.go
+++ b/examples/distribution/client.go
@@ -22,9 +22,10 @@ const (
 
 // Configuration for the early in-memory refreshes.
 const (
-	minRefreshTime = 100 * time.Millisecond
-	maxRefreshTime = 500 * time.Millisecond
-	retryBaseDelay = time.Second
+	minRefreshTime         = 100 * time.Millisecond
+	maxRefreshTime         = 500 * time.Millisecond
+	synchronousRefreshTime = 30 * time.Second
+	retryBaseDelay         = time.Second
 )
 
 // Configuration for the refresh coalescing.
@@ -37,7 +38,7 @@ func newAPIClient(distributedStorage sturdyc.DistributedStorage) *apiClient {
 	return &apiClient{
 		cache: sturdyc.New[any](capacity, numberOfShards, ttl, percentageOfRecordsToEvictWhenFull,
 			sturdyc.WithMissingRecordStorage(),
-			sturdyc.WithEarlyRefreshes(minRefreshTime, maxRefreshTime, retryBaseDelay),
+			sturdyc.WithEarlyRefreshes(minRefreshTime, maxRefreshTime, synchronousRefreshTime, retryBaseDelay),
 			sturdyc.WithRefreshCoalescing(idealBufferSize, bufferTimeout),
 			sturdyc.WithDistributedStorage(distributedStorage),
 		),

--- a/examples/generics/main.go
+++ b/examples/generics/main.go
@@ -54,12 +54,14 @@ func main() {
 	// used to spread out the refreshes for entries evenly over time.
 	minRefreshDelay := time.Second
 	maxRefreshDelay := time.Second * 2
+	// Set a synchronous refresh delay for when we want a refresh to happen synchronously.
+	synchronousRefreshDelay := time.Second * 30
 	// The base for exponential backoff when retrying a refresh.
 	retryBaseDelay := time.Millisecond * 10
 
 	// Create a new cache client with the specified configuration.
 	cacheClient := sturdyc.New[any](capacity, numShards, ttl, evictionPercentage,
-		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, retryBaseDelay),
+		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, synchronousRefreshDelay, retryBaseDelay),
 		sturdyc.WithRefreshCoalescing(10, time.Second*15),
 	)
 

--- a/examples/missing/main.go
+++ b/examples/missing/main.go
@@ -51,12 +51,14 @@ func main() {
 	// used to spread out the refreshes for entries evenly over time.
 	minRefreshDelay := time.Millisecond * 10
 	maxRefreshDelay := time.Millisecond * 30
+	// Set a synchronous refresh delay for when we want a refresh to happen synchronously.
+	synchronousRefreshDelay := time.Second * 30
 	// The base for exponential backoff when retrying a refresh.
 	retryBaseDelay := time.Millisecond * 10
 
 	// Create a cache client with the specified configuration.
 	cacheClient := sturdyc.New[string](capacity, numShards, ttl, evictionPercentage,
-		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, retryBaseDelay),
+		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, synchronousRefreshDelay, retryBaseDelay),
 		sturdyc.WithMissingRecordStorage(),
 	)
 

--- a/examples/permutations/main.go
+++ b/examples/permutations/main.go
@@ -56,12 +56,14 @@ func main() {
 	// used to spread out the refreshes for entries evenly over time.
 	minRefreshDelay := time.Second
 	maxRefreshDelay := time.Second * 2
+	// Set a synchronous refresh delay for when we want a refresh to happen synchronously.
+	synchronousRefreshDelay := time.Second * 30
 	// The base for exponential backoff when retrying a refresh.
 	retryBaseDelay := time.Millisecond * 10
 
 	// Create a new cache client with the specified configuration.
 	cacheClient := sturdyc.New[string](capacity, numShards, ttl, evictionPercentage,
-		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, retryBaseDelay),
+		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, synchronousRefreshDelay, retryBaseDelay),
 	)
 
 	// We will fetch these IDs using various option sets, meaning that the ID alone

--- a/examples/permutations/main.go
+++ b/examples/permutations/main.go
@@ -23,7 +23,7 @@ func NewOrderAPI(c *sturdyc.Client[string]) *OrderAPI {
 }
 
 func (a *OrderAPI) OrderStatus(ctx context.Context, ids []string, opts OrderOptions) (map[string]string, error) {
-	// We use the  PermutedBatchKeyFn when an ID isn't enough to uniquely identify a
+	// We use the PermutedBatchKeyFn when an ID isn't enough to uniquely identify a
 	// record. The cache is going to store each id once per set of options. In a more
 	// realistic scenario, the opts would be query params or arguments to a DB query.
 	cacheKeyFn := a.PermutatedBatchKeyFn("key", opts)

--- a/examples/refreshes/main.go
+++ b/examples/refreshes/main.go
@@ -42,20 +42,22 @@ func main() {
 	evictionPercentage := 10
 
 	// ===========================================================
-	// =================== Background refreshes ==================
+	// ===================== Early refreshes ====================
 	// ===========================================================
-	// Set a minimum and maximum refresh delay for the record. This is
-	// used to spread out the refreshes of our entries evenly over time.
-	// We don't want our outgoing requests graph to look like a comb.
+	// Set a minimum and maximum refresh delay for the records. This is used to
+	// spread out the refreshes of our records evenly over time. If we're running
+	// our application across 100 containers, we don't want to send a spike of
+	// refreshes from every container every 30 ms. Instead, we'll use some
+	// randomization to spread them out evenly between 10 and 30 ms.
 	minRefreshDelay := time.Millisecond * 10
 	maxRefreshDelay := time.Millisecond * 30
 	// Set a synchronous refresh delay for when we want a refresh to happen synchronously.
 	synchronousRefreshDelay := time.Second * 30
-	// The base used for exponential backoff when retrying a refresh. Most of the
-	// time, we perform refreshes well in advance of the records expiry time.
-	// Hence, we can use this to make it easier for a system that is having
-	// trouble to get back on it's feet by making fewer refreshes when we're
-	// seeing a lot of errors. Once we receive a successful response, the
+	// The base used for exponential backoff when retrying a background refresh.
+	// Most of the time, we perform refreshes well in advance of the records
+	// expiry time. Hence, we can use this to make it easier for a system that
+	// is having trouble to get back on it's feet by making fewer refreshes when
+	// we're seeing a lot of errors. Once we receive a successful response, the
 	// refreshes return to their original frequency. You can set this to 0
 	// if you don't want this behavior.
 	retryBaseDelay := time.Millisecond * 10

--- a/examples/refreshes/main.go
+++ b/examples/refreshes/main.go
@@ -49,6 +49,8 @@ func main() {
 	// We don't want our outgoing requests graph to look like a comb.
 	minRefreshDelay := time.Millisecond * 10
 	maxRefreshDelay := time.Millisecond * 30
+	// Set a synchronous refresh delay for when we want a refresh to happen synchronously.
+	synchronousRefreshDelay := time.Second * 30
 	// The base used for exponential backoff when retrying a refresh. Most of the
 	// time, we perform refreshes well in advance of the records expiry time.
 	// Hence, we can use this to make it easier for a system that is having
@@ -60,7 +62,7 @@ func main() {
 
 	// Create a cache client with the specified configuration.
 	cacheClient := sturdyc.New[string](capacity, numShards, ttl, evictionPercentage,
-		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, retryBaseDelay),
+		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, synchronousRefreshDelay, retryBaseDelay),
 	)
 
 	// Create a new API instance with the cache client.

--- a/fetch.go
+++ b/fetch.go
@@ -88,7 +88,7 @@ func getFetch[V, T any](ctx context.Context, c *Client[T], key string, fetchFn F
 
 // GetOrFetch attempts to retrieve the specified key from the cache. If the value
 // is absent, it invokes the fetchFn function to obtain it and then stores the result.
-// Additionally, when background refreshes are enabled, GetOrFetch determines if the record
+// Additionally, when early refreshes are enabled, GetOrFetch determines if the record
 // needs refreshing and, if necessary, schedules this task for background execution.
 //
 // Parameters:

--- a/fetch_test.go
+++ b/fetch_test.go
@@ -702,3 +702,659 @@ func TestGetFetchBatchConvertsDeletedRecordsToMissingRecords(t *testing.T) {
 		t.Errorf("expected key3 to not be returned by Get")
 	}
 }
+
+func TestGetFetchSynchronousRefreshes(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	capacity := 1000
+	numShards := 10
+	ttl := time.Hour
+	evictionPercentage := 10
+	minBackgroundRefreshDelay := time.Second
+	maxBackgroundRefreshDelay := time.Second * 2
+	synchronousRefreshDelay := time.Second * 10
+	retryInterval := time.Millisecond * 10
+	clock := sturdyc.NewTestClock(time.Now())
+
+	c := sturdyc.New[string](capacity, numShards, ttl, evictionPercentage,
+		sturdyc.WithNoContinuousEvictions(),
+		sturdyc.WithEarlyRefreshes(minBackgroundRefreshDelay, maxBackgroundRefreshDelay, synchronousRefreshDelay, retryInterval),
+		sturdyc.WithMissingRecordStorage(),
+		sturdyc.WithClock(clock),
+	)
+
+	id := "1"
+	fetchObserver := NewFetchObserver(1)
+	fetchObserver.Response(id)
+
+	res, err := sturdyc.GetOrFetch(ctx, c, id, fetchObserver.Fetch)
+	<-fetchObserver.FetchCompleted
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if res != "value1" {
+		t.Errorf("expected value1, got %v", res)
+	}
+
+	// Now, let's make the fetchObserver return a new value, and only move the
+	// clock enough to warrant a background refresh. The value we get should
+	// still be the same as the previous one because the refresh happens in the
+	// background.
+	fetchObserver.Clear()
+	fetchObserver.Response("2")
+	clock.Add(maxBackgroundRefreshDelay + 1)
+	res, err = sturdyc.GetOrFetch(ctx, c, id, fetchObserver.Fetch)
+	<-fetchObserver.FetchCompleted
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if res != "value1" {
+		t.Errorf("expected value1, got %v", res)
+	}
+
+	// Now we can wait for the background refresh to complete, and then assert
+	// that the next time we ask for this ID we'll get the new value.
+	time.Sleep(time.Millisecond * 100)
+	res, err = sturdyc.GetOrFetch(ctx, c, id, fetchObserver.Fetch)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if res != "value2" {
+		t.Errorf("expected value2, got %v", res)
+	}
+
+	// Let's do this again, but this time we'll move the clock passed the synchronous refresh delay.
+	// This should result in a synchronous refresh and we should get the new value right away.
+	fetchObserver.Clear()
+	fetchObserver.Response("3")
+	clock.Add(synchronousRefreshDelay + 1)
+	res, err = sturdyc.GetOrFetch(ctx, c, id, fetchObserver.Fetch)
+	<-fetchObserver.FetchCompleted
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if res != "value3" {
+		t.Errorf("expected value3, got %v", res)
+	}
+	fetchObserver.AssertFetchCount(t, 3)
+}
+
+func TestGetFetchBatchSynchronousRefreshes(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	capacity := 1000
+	numShards := 10
+	ttl := time.Hour
+	evictionPercentage := 10
+	minBackgroundRefreshDelay := time.Second
+	maxBackgroundRefreshDelay := time.Second * 2
+	synchronousRefreshDelay := time.Second * 10
+	retryInterval := time.Millisecond * 10
+	clock := sturdyc.NewTestClock(time.Now())
+
+	c := sturdyc.New[string](capacity, numShards, ttl, evictionPercentage,
+		sturdyc.WithNoContinuousEvictions(),
+		sturdyc.WithEarlyRefreshes(minBackgroundRefreshDelay, maxBackgroundRefreshDelay, synchronousRefreshDelay, retryInterval),
+		sturdyc.WithMissingRecordStorage(),
+		sturdyc.WithClock(clock),
+	)
+
+	firstBatchOfIDs := []string{"1", "2", "3"}
+	fetchObserver := NewFetchObserver(2)
+	fetchObserver.BatchResponse(firstBatchOfIDs)
+
+	_, err := sturdyc.GetOrFetchBatch(ctx, c, firstBatchOfIDs, c.BatchKeyFn("item"), fetchObserver.FetchBatch)
+	<-fetchObserver.FetchCompleted
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	fetchObserver.AssertRequestedRecords(t, firstBatchOfIDs)
+	fetchObserver.AssertFetchCount(t, 1)
+
+	// Now, let's move the clock 5 seconds and then request another batch of IDs.
+	clock.Add(time.Second * 5)
+	secondBatchOfIDs := []string{"4", "5", "6"}
+	fetchObserver.BatchResponse(secondBatchOfIDs)
+	_, err = sturdyc.GetOrFetchBatch(ctx, c, secondBatchOfIDs, c.BatchKeyFn("item"), fetchObserver.FetchBatch)
+	<-fetchObserver.FetchCompleted
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	fetchObserver.AssertRequestedRecords(t, secondBatchOfIDs)
+	fetchObserver.AssertFetchCount(t, 2)
+
+	// At this point, we should have IDs 1-3 in the cache that are 5  seconds
+	// old, and IDs 4-6 that are completely new. If we now move the clock another
+	// 5 seconds, we should reach the point where IDs 1-3 are due for a
+	// synchronous refresh, and IDs 4-6 are due for a background refresh.
+	clock.Add((time.Second * 5) + 1)
+
+	fullBatchOfIDs := []string{"1", "2", "3", "4", "5", "6"}
+	fetchObserver.BatchResponse(firstBatchOfIDs)
+	_, err = sturdyc.GetOrFetchBatch(ctx, c, fullBatchOfIDs, c.BatchKeyFn("item"), fetchObserver.FetchBatch)
+	// We'll assert that two refreshes happened. One synchronous refresh and one background refresh.
+	<-fetchObserver.FetchCompleted
+	<-fetchObserver.FetchCompleted
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	fetchObserver.AssertFetchCount(t, 4)
+}
+
+func TestGetFetchSynchronousRefreshConvertsToMissingRecord(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	capacity := 1000
+	numShards := 10
+	ttl := time.Hour
+	evictionPercentage := 10
+	minBackgroundRefreshDelay := time.Second
+	maxBackgroundRefreshDelay := time.Second * 2
+	synchronousRefreshDelay := time.Second * 10
+	retryInterval := time.Millisecond * 10
+	clock := sturdyc.NewTestClock(time.Now())
+
+	c := sturdyc.New[string](capacity, numShards, ttl, evictionPercentage,
+		sturdyc.WithNoContinuousEvictions(),
+		sturdyc.WithEarlyRefreshes(minBackgroundRefreshDelay, maxBackgroundRefreshDelay, synchronousRefreshDelay, retryInterval),
+		sturdyc.WithMissingRecordStorage(),
+		sturdyc.WithClock(clock),
+	)
+
+	id := "1"
+	fetchObserver := NewFetchObserver(1)
+	fetchObserver.Response(id)
+
+	res, err := sturdyc.GetOrFetch(ctx, c, id, fetchObserver.Fetch)
+	<-fetchObserver.FetchCompleted
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if res != "value1" {
+		t.Errorf("expected value1, got %v", res)
+	}
+
+	// Here, we'll set up the next request to return a not found error. Given
+	// that we have missing record storage enabled, we'll expect that the
+	// synchronous refresh returns a sturdyc.MissingRecord error.
+	fetchObserver.Clear()
+	fetchObserver.Err(sturdyc.ErrNotFound)
+	clock.Add(synchronousRefreshDelay + 1)
+
+	_, err = sturdyc.GetOrFetch(ctx, c, id, fetchObserver.Fetch)
+	if !errors.Is(err, sturdyc.ErrMissingRecord) {
+		t.Fatalf("expected ErrMissingRecord, got %v", err)
+	}
+	<-fetchObserver.FetchCompleted
+	fetchObserver.AssertFetchCount(t, 2)
+	if c.Size() != 1 {
+		t.Errorf("expected cache size to be 1, got %d", c.Size())
+	}
+
+	// Let's also make sure that the record can reappear again.
+	fetchObserver.Clear()
+	fetchObserver.Response("2")
+	clock.Add(synchronousRefreshDelay + 1)
+
+	res, err = sturdyc.GetOrFetch(ctx, c, id, fetchObserver.Fetch)
+	<-fetchObserver.FetchCompleted
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if res != "value2" {
+		t.Errorf("expected value2, got %v", res)
+	}
+	fetchObserver.AssertFetchCount(t, 3)
+}
+
+func TestGetFetchBatchSynchronousRefreshConvertsToMissingRecord(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	capacity := 1000
+	numShards := 10
+	ttl := time.Hour
+	evictionPercentage := 10
+	minBackgroundRefreshDelay := time.Second
+	maxBackgroundRefreshDelay := time.Second * 2
+	synchronousRefreshDelay := time.Second * 10
+	retryInterval := time.Millisecond * 10
+	clock := sturdyc.NewTestClock(time.Now())
+
+	c := sturdyc.New[string](capacity, numShards, ttl, evictionPercentage,
+		sturdyc.WithNoContinuousEvictions(),
+		sturdyc.WithEarlyRefreshes(minBackgroundRefreshDelay, maxBackgroundRefreshDelay, synchronousRefreshDelay, retryInterval),
+		sturdyc.WithMissingRecordStorage(),
+		sturdyc.WithClock(clock),
+	)
+
+	ids := []string{"1", "2", "3", "4", "5", "6"}
+	fetchObserver := NewFetchObserver(1)
+	fetchObserver.BatchResponse(ids)
+
+	res, err := sturdyc.GetOrFetchBatch(ctx, c, ids, c.BatchKeyFn("item"), fetchObserver.FetchBatch)
+	<-fetchObserver.FetchCompleted
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(res) != 6 {
+		t.Fatalf("expected 6 records, got %d", len(res))
+	}
+	if c.Size() != 6 {
+		t.Errorf("expected cache size to be 6, got %d", c.Size())
+	}
+	fetchObserver.AssertRequestedRecords(t, ids)
+	fetchObserver.AssertFetchCount(t, 1)
+
+	// Now, let's move the clock passed the synchronous refresh delay,
+	// and make the refresh only return values for IDs 1-3.
+	clock.Add(synchronousRefreshDelay + 1)
+	fetchObserver.Clear()
+	fetchObserver.BatchResponse([]string{"1", "2", "3"})
+
+	res, err = sturdyc.GetOrFetchBatch(ctx, c, ids, c.BatchKeyFn("item"), fetchObserver.FetchBatch)
+	<-fetchObserver.FetchCompleted
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(res) != 3 {
+		t.Fatalf("expected 3 records, got %d", len(res))
+	}
+	if c.Size() != 6 {
+		t.Errorf("expected cache size to be 6, got %d", c.Size())
+	}
+	fetchObserver.AssertRequestedRecords(t, ids)
+	fetchObserver.AssertFetchCount(t, 2)
+
+	// Next, let's assert that the records were successfully stored as missing.
+	clock.Add(minBackgroundRefreshDelay - 1)
+	res, err = sturdyc.GetOrFetchBatch(ctx, c, ids, c.BatchKeyFn("item"), fetchObserver.FetchBatch)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(res) != 3 {
+		t.Fatalf("expected 3 records, got %d", len(res))
+	}
+	if c.Size() != 6 {
+		t.Errorf("expected cache size to be 6, got %d", c.Size())
+	}
+
+	// And finally, let's make sure that the records can reappear again.
+	clock.Add(synchronousRefreshDelay)
+	fetchObserver.Clear()
+	fetchObserver.BatchResponse(ids)
+
+	res, err = sturdyc.GetOrFetchBatch(ctx, c, ids, c.BatchKeyFn("item"), fetchObserver.FetchBatch)
+	<-fetchObserver.FetchCompleted
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(res) != 6 {
+		t.Fatalf("expected 6 records, got %d", len(res))
+	}
+	if c.Size() != 6 {
+		t.Errorf("expected cache size to be 6, got %d", c.Size())
+	}
+	fetchObserver.AssertRequestedRecords(t, ids)
+}
+
+func TestGetFetchSynchronousRefreshDeletion(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	capacity := 1000
+	numShards := 10
+	ttl := time.Hour
+	evictionPercentage := 10
+	minBackgroundRefreshDelay := time.Second
+	maxBackgroundRefreshDelay := time.Second * 2
+	synchronousRefreshDelay := time.Second * 10
+	retryInterval := time.Millisecond * 10
+	clock := sturdyc.NewTestClock(time.Now())
+
+	c := sturdyc.New[string](capacity, numShards, ttl, evictionPercentage,
+		sturdyc.WithNoContinuousEvictions(),
+		sturdyc.WithEarlyRefreshes(minBackgroundRefreshDelay, maxBackgroundRefreshDelay, synchronousRefreshDelay, retryInterval),
+		sturdyc.WithClock(clock),
+	)
+
+	id := "1"
+	fetchObserver := NewFetchObserver(1)
+	fetchObserver.Response(id)
+
+	res, err := sturdyc.GetOrFetch(ctx, c, id, fetchObserver.Fetch)
+	<-fetchObserver.FetchCompleted
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if res != "value1" {
+		t.Errorf("expected value1, got %v", res)
+	}
+
+	// Here, we'll set up the next request to return a not found error. Given
+	// that we have missing record storage enabled, we'll expect that the
+	// synchronous refresh returns a sturdyc.MissingRecord error.
+	fetchObserver.Clear()
+	fetchObserver.Err(sturdyc.ErrNotFound)
+	clock.Add(synchronousRefreshDelay + 1)
+
+	_, err = sturdyc.GetOrFetch(ctx, c, id, fetchObserver.Fetch)
+	if !errors.Is(err, sturdyc.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+	<-fetchObserver.FetchCompleted
+	fetchObserver.AssertFetchCount(t, 2)
+	if c.Size() != 0 {
+		t.Errorf("expected cache size to be 0, got %d", c.Size())
+	}
+
+	// Let's also make sure that the record can reappear again.
+	clock.Add(synchronousRefreshDelay)
+	fetchObserver.Clear()
+	fetchObserver.Response(id)
+	res, err = sturdyc.GetOrFetch(ctx, c, id, fetchObserver.Fetch)
+	<-fetchObserver.FetchCompleted
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if res != "value1" {
+		t.Errorf("expected value1, got %v", res)
+	}
+	if c.Size() != 1 {
+		t.Errorf("expected cache size to be 1, got %d", c.Size())
+	}
+	fetchObserver.AssertFetchCount(t, 3)
+}
+
+func TestGetFetchBatchSynchronousRefreshDeletion(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	capacity := 1000
+	numShards := 10
+	ttl := time.Hour
+	evictionPercentage := 10
+	minBackgroundRefreshDelay := time.Second
+	maxBackgroundRefreshDelay := time.Second * 2
+	synchronousRefreshDelay := time.Second * 10
+	retryInterval := time.Millisecond * 10
+	clock := sturdyc.NewTestClock(time.Now())
+
+	c := sturdyc.New[string](capacity, numShards, ttl, evictionPercentage,
+		sturdyc.WithNoContinuousEvictions(),
+		sturdyc.WithEarlyRefreshes(minBackgroundRefreshDelay, maxBackgroundRefreshDelay, synchronousRefreshDelay, retryInterval),
+		sturdyc.WithClock(clock),
+	)
+
+	ids := []string{"1", "2", "3", "4", "5", "6"}
+	fetchObserver := NewFetchObserver(1)
+	fetchObserver.BatchResponse(ids)
+
+	res, err := sturdyc.GetOrFetchBatch(ctx, c, ids, c.BatchKeyFn("item"), fetchObserver.FetchBatch)
+	<-fetchObserver.FetchCompleted
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(res) != 6 {
+		t.Fatalf("expected 6 records, got %d", len(res))
+	}
+	if c.Size() != 6 {
+		t.Errorf("expected cache size to be 6, got %d", c.Size())
+	}
+	fetchObserver.AssertRequestedRecords(t, ids)
+	fetchObserver.AssertFetchCount(t, 1)
+
+	// Now, let's move the clock passed the synchronous refresh delay,
+	// and make the refresh only return values for IDs 1-3.
+	clock.Add(synchronousRefreshDelay + 1)
+	fetchObserver.Clear()
+	fetchObserver.BatchResponse([]string{"1", "2", "3"})
+
+	res, err = sturdyc.GetOrFetchBatch(ctx, c, ids, c.BatchKeyFn("item"), fetchObserver.FetchBatch)
+	<-fetchObserver.FetchCompleted
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(res) != 3 {
+		t.Fatalf("expected 3 records, got %d", len(res))
+	}
+	// IDs 4-6 should not have been deleted.
+	if c.Size() != 3 {
+		t.Errorf("expected cache size to be 3, got %d", c.Size())
+	}
+	fetchObserver.AssertRequestedRecords(t, ids)
+	fetchObserver.AssertFetchCount(t, 2)
+
+	// Next, let's assert that the records doesn't reappear the next time we ask for the same IDs.
+	fetchObserver.Clear()
+	fetchObserver.BatchResponse([]string{})
+	clock.Add(minBackgroundRefreshDelay - 1)
+
+	res, err = sturdyc.GetOrFetchBatch(ctx, c, ids, c.BatchKeyFn("item"), fetchObserver.FetchBatch)
+	<-fetchObserver.FetchCompleted
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(res) != 3 {
+		t.Fatalf("expected 3 records, got %d", len(res))
+	}
+	if c.Size() != 3 {
+		t.Errorf("expected cache size to be 3, got %d", c.Size())
+	}
+	// IDs 4-6 should have been deleted, hence we should get another outgoing request.
+	fetchObserver.AssertFetchCount(t, 3)
+	fetchObserver.AssertRequestedRecords(t, []string{"4", "5", "6"})
+
+	// Finally, let's make sure that the records can reappear again.
+	clock.Add(synchronousRefreshDelay)
+	fetchObserver.Clear()
+	fetchObserver.BatchResponse(ids)
+
+	res, err = sturdyc.GetOrFetchBatch(ctx, c, ids, c.BatchKeyFn("item"), fetchObserver.FetchBatch)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(res) != 6 {
+		t.Fatalf("expected 6 records, got %d", len(res))
+	}
+	if c.Size() != 6 {
+		t.Errorf("expected cache size to be 6, got %d", c.Size())
+	}
+	fetchObserver.AssertRequestedRecords(t, ids)
+	fetchObserver.AssertFetchCount(t, 4)
+}
+
+func TestGetFetchSynchronousRefreshFailureGivesLatestValue(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	capacity := 1000
+	numShards := 10
+	ttl := time.Hour
+	evictionPercentage := 10
+	minBackgroundRefreshDelay := time.Second
+	maxBackgroundRefreshDelay := time.Second * 2
+	synchronousRefreshDelay := time.Second * 10
+	retryInterval := time.Millisecond * 10
+	clock := sturdyc.NewTestClock(time.Now())
+
+	c := sturdyc.New[string](capacity, numShards, ttl, evictionPercentage,
+		sturdyc.WithNoContinuousEvictions(),
+		sturdyc.WithEarlyRefreshes(minBackgroundRefreshDelay, maxBackgroundRefreshDelay, synchronousRefreshDelay, retryInterval),
+		sturdyc.WithMissingRecordStorage(),
+		sturdyc.WithClock(clock),
+	)
+
+	id := "1"
+	fetchObserver := NewFetchObserver(1)
+	fetchObserver.Response(id)
+
+	res, err := sturdyc.GetOrFetch(ctx, c, id, fetchObserver.Fetch)
+	<-fetchObserver.FetchCompleted
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if res != "value1" {
+		t.Errorf("expected value1, got %v", res)
+	}
+
+	// Here, we'll set up the next request to return an error. Given that
+	// we still have this key cached, we expect the cache to give us an
+	// ErrOnlyCachedRecords error along with the cached value.
+	fetchObserver.Clear()
+	fetchObserver.Err(errors.New("error"))
+	clock.Add(synchronousRefreshDelay + 1)
+
+	res, err = sturdyc.GetOrFetch(ctx, c, id, fetchObserver.Fetch)
+	<-fetchObserver.FetchCompleted
+	if !errors.Is(err, sturdyc.ErrOnlyCachedRecords) {
+		t.Fatalf("expected ErrOnlyCachedRecords, got %v", err)
+	}
+	if res != "value1" {
+		t.Errorf("expected value1, got %v", res)
+	}
+	fetchObserver.AssertFetchCount(t, 2)
+
+	// Now, requesting the same ID again should result in another synchronous
+	// refresh without us having to move the clock. Let's set this one up to return
+	// an actual value.
+	fetchObserver.Clear()
+	fetchObserver.Response("2")
+
+	res, err = sturdyc.GetOrFetch(ctx, c, id, fetchObserver.Fetch)
+	<-fetchObserver.FetchCompleted
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if res != "value2" {
+		t.Errorf("expected value2, got %v", res)
+	}
+	fetchObserver.AssertFetchCount(t, 3)
+}
+
+func TestGetFetchBatchSynchronousRefreshFailureGivesLatestValue(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	capacity := 1000
+	numShards := 10
+	ttl := time.Hour
+	evictionPercentage := 10
+	minBackgroundRefreshDelay := time.Second
+	maxBackgroundRefreshDelay := time.Second * 2
+	synchronousRefreshDelay := time.Second * 10
+	retryInterval := time.Millisecond * 10
+	clock := sturdyc.NewTestClock(time.Now())
+
+	c := sturdyc.New[string](capacity, numShards, ttl, evictionPercentage,
+		sturdyc.WithNoContinuousEvictions(),
+		sturdyc.WithEarlyRefreshes(minBackgroundRefreshDelay, maxBackgroundRefreshDelay, synchronousRefreshDelay, retryInterval),
+		sturdyc.WithMissingRecordStorage(),
+		sturdyc.WithClock(clock),
+	)
+
+	ids := []string{"1", "2", "3", "4", "5"}
+	fetchObserver := NewFetchObserver(1)
+	fetchObserver.BatchResponse(ids)
+
+	res, err := sturdyc.GetOrFetchBatch(ctx, c, ids, c.BatchKeyFn("item"), fetchObserver.FetchBatch)
+	<-fetchObserver.FetchCompleted
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(res) != 5 {
+		t.Fatalf("expected 5 records, got %d", len(res))
+	}
+	fetchObserver.AssertRequestedRecords(t, ids)
+	fetchObserver.AssertFetchCount(t, 1)
+
+	// Now, let's move the clock passed the synchronous refresh
+	// delay, and make the next call return an error.
+	clock.Add(synchronousRefreshDelay + 1)
+	fetchObserver.Clear()
+	fetchObserver.Err(errors.New("error"))
+
+	res, err = sturdyc.GetOrFetchBatch(ctx, c, ids, c.BatchKeyFn("item"), fetchObserver.FetchBatch)
+	<-fetchObserver.FetchCompleted
+	if !errors.Is(err, sturdyc.ErrOnlyCachedRecords) {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(res) != 5 {
+		t.Fatalf("expected 5 records, got %d", len(res))
+	}
+	fetchObserver.AssertRequestedRecords(t, ids)
+	fetchObserver.AssertFetchCount(t, 2)
+
+	// If a synchronous refresh fails, we won't do any exponential backoff.
+	clock.Add(time.Millisecond)
+	res, err = sturdyc.GetOrFetchBatch(ctx, c, ids, c.BatchKeyFn("item"), fetchObserver.FetchBatch)
+	<-fetchObserver.FetchCompleted
+	if !errors.Is(err, sturdyc.ErrOnlyCachedRecords) {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(res) != 5 {
+		t.Fatalf("expected 5 records, got %d", len(res))
+	}
+	fetchObserver.AssertRequestedRecords(t, ids)
+	fetchObserver.AssertFetchCount(t, 3)
+}
+
+func TestGetFetchSynchronousRefreshStampedeProtection(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	capacity := 10
+	numShards := 2
+	ttl := time.Second * 2
+	evictionPercentage := 10
+	clock := sturdyc.NewTestClock(time.Now())
+	minRefreshDelay := time.Millisecond * 500
+	maxRefreshDelay := time.Millisecond * 500
+	synchronousRefreshDelay := time.Second
+	refreshRetryInterval := time.Millisecond * 10
+
+	// The cache is going to have a 2 second TTL, and the first refresh should happen within a second.
+	c := sturdyc.New[string](capacity, numShards, ttl, evictionPercentage,
+		sturdyc.WithNoContinuousEvictions(),
+		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, synchronousRefreshDelay, refreshRetryInterval),
+		sturdyc.WithMissingRecordStorage(),
+		sturdyc.WithClock(clock),
+	)
+
+	id := "1"
+	fetchObserver := NewFetchObserver(1000)
+	fetchObserver.Response(id)
+
+	// We will start the test by trying to get key1, which wont exist in the sturdyc. Hence,
+	// the fetch function is going to get called and we'll set the initial value to val1.
+	sturdyc.GetOrFetch[string](ctx, c, id, fetchObserver.Fetch)
+
+	<-fetchObserver.FetchCompleted
+	fetchObserver.AssertFetchCount(t, 1)
+
+	// Now, we're going to go past the synchronous refresh delay and try to retrieve the key from 1000 goroutines at once.
+	numGoroutines := 1000
+	clock.Add(synchronousRefreshDelay + 1)
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			defer wg.Done()
+			_, err := sturdyc.GetOrFetch(ctx, c, id, fetchObserver.Fetch)
+			if err != nil {
+				panic(err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	<-fetchObserver.FetchCompleted
+	fetchObserver.AssertFetchCount(t, 2)
+}
+
+func TestGetFetchBatchMixOfSynchronousAndAsynchronousRefreshes(t *testing.T) {}

--- a/fetch_test.go
+++ b/fetch_test.go
@@ -61,12 +61,13 @@ func TestGetOrFetchStampedeProtection(t *testing.T) {
 	clock := sturdyc.NewTestClock(time.Now())
 	minRefreshDelay := time.Millisecond * 500
 	maxRefreshDelay := time.Millisecond * 500
+	synchronousRefreshDelay := time.Second
 	refreshRetryInterval := time.Millisecond * 10
 
 	// The cache is going to have a 2 second TTL, and the first refresh should happen within a second.
 	c := sturdyc.New[string](capacity, numShards, ttl, evictionPercentage,
 		sturdyc.WithNoContinuousEvictions(),
-		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, refreshRetryInterval),
+		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, synchronousRefreshDelay, refreshRetryInterval),
 		sturdyc.WithMissingRecordStorage(),
 		sturdyc.WithClock(clock),
 	)
@@ -112,12 +113,13 @@ func TestGetOrFetchRefreshRetries(t *testing.T) {
 	evictionPercentage := 10
 	minRefreshDelay := time.Second
 	maxRefreshDelay := time.Second * 2
+	synchronousRefreshDelay := time.Second * 10
 	retryInterval := time.Millisecond * 10
 	clock := sturdyc.NewTestClock(time.Now())
 
 	c := sturdyc.New[string](capacity, numShards, ttl, evictionPercentage,
 		sturdyc.WithNoContinuousEvictions(),
-		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, retryInterval),
+		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, synchronousRefreshDelay, retryInterval),
 		sturdyc.WithMissingRecordStorage(),
 		sturdyc.WithClock(clock),
 	)
@@ -167,12 +169,13 @@ func TestGetOrFetchMissingRecord(t *testing.T) {
 	evictionPercentage := 20
 	minRefreshDelay := time.Second
 	maxRefreshDelay := time.Second * 2
+	synchronousRefreshDelay := time.Second * 10
 	retryInterval := time.Millisecond * 10
 	clock := sturdyc.NewTestClock(time.Now())
 	c := sturdyc.New[string](capacity, numShards, ttl, evictionPercentage,
 		sturdyc.WithNoContinuousEvictions(),
 		sturdyc.WithClock(clock),
-		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, retryInterval),
+		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, synchronousRefreshDelay, retryInterval),
 		sturdyc.WithMissingRecordStorage(),
 	)
 
@@ -266,13 +269,14 @@ func TestBatchGetOrFetchNilMapMissingRecords(t *testing.T) {
 	numShards := 1
 	ttl := time.Minute
 	evictionPercentage := 50
-	minRefreshDelay := time.Minute
-	maxRefreshDelay := time.Minute * 2
+	minRefreshDelay := time.Second
+	maxRefreshDelay := time.Second * 2
+	synchronousRefreshDelay := time.Second * 10
 	retryInterval := time.Second
 	clock := sturdyc.NewTestClock(time.Now())
 	c := sturdyc.New[string](capacity, numShards, ttl, evictionPercentage,
 		sturdyc.WithNoContinuousEvictions(),
-		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, retryInterval),
+		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, synchronousRefreshDelay, retryInterval),
 		sturdyc.WithMissingRecordStorage(),
 		sturdyc.WithClock(clock),
 	)
@@ -316,11 +320,12 @@ func TestGetOrFetchBatchRetries(t *testing.T) {
 	evictionPercentage := 10
 	minRefreshDelay := time.Hour
 	maxRefreshDelay := time.Hour * 2
+	synchronousRefreshDelay := time.Hour * 4
 	retryInterval := time.Second
 	clock := sturdyc.NewTestClock(time.Now())
 	c := sturdyc.New[string](capacity, numShards, ttl, evictionPercentage,
 		sturdyc.WithNoContinuousEvictions(),
-		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, retryInterval),
+		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, synchronousRefreshDelay, retryInterval),
 		sturdyc.WithMissingRecordStorage(),
 		sturdyc.WithClock(clock),
 	)
@@ -428,10 +433,11 @@ func TestGetOrFetchBatchStampedeProtection(t *testing.T) {
 	clock := sturdyc.NewTestClock(time.Now())
 	minRefreshDelay := time.Millisecond * 500
 	maxRefreshDelay := time.Millisecond * 1000
+	synchronousRefreshDelay := time.Millisecond * 1500
 	refreshRetryInterval := time.Millisecond * 10
 	c := sturdyc.New[string](capacity, shards, ttl, evictionPercentage,
 		sturdyc.WithNoContinuousEvictions(),
-		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, refreshRetryInterval),
+		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, synchronousRefreshDelay, refreshRetryInterval),
 		sturdyc.WithMissingRecordStorage(),
 		sturdyc.WithClock(clock),
 		sturdyc.WithMetrics(newTestMetricsRecorder(shards)),
@@ -502,11 +508,12 @@ func TestGetOrFetchDeletesRecordsThatHaveBeenRemovedAtTheSource(t *testing.T) {
 	clock := sturdyc.NewTestClock(time.Now())
 	minRefreshDelay := time.Millisecond * 500
 	maxRefreshDelay := time.Second
+	synchronousRefreshDelay := time.Minute
 	refreshRetryInterval := time.Millisecond * 10
 
 	c := sturdyc.New[string](capacity, numShards, ttl, evictionPercentage,
 		sturdyc.WithNoContinuousEvictions(),
-		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, refreshRetryInterval),
+		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, synchronousRefreshDelay, refreshRetryInterval),
 		sturdyc.WithClock(clock),
 	)
 
@@ -548,11 +555,12 @@ func TestGetOrFetchConvertsDeletedRecordsToMissingRecords(t *testing.T) {
 	clock := sturdyc.NewTestClock(time.Now())
 	minRefreshDelay := time.Millisecond * 500
 	maxRefreshDelay := time.Second
+	synchronousRefreshDelay := time.Minute
 	refreshRetryInterval := time.Millisecond * 10
 
 	c := sturdyc.New[string](capacity, numShards, ttl, evictionPercentage,
 		sturdyc.WithNoContinuousEvictions(),
-		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, refreshRetryInterval),
+		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, synchronousRefreshDelay, refreshRetryInterval),
 		sturdyc.WithMissingRecordStorage(),
 		sturdyc.WithClock(clock),
 	)
@@ -601,11 +609,12 @@ func TestGetOrFetchBatchDeletesRecordsThatHaveBeenRemovedAtTheSource(t *testing.
 	clock := sturdyc.NewTestClock(time.Now())
 	minRefreshDelay := time.Millisecond * 500
 	maxRefreshDelay := time.Second
+	synchronousRefreshDelay := time.Minute
 	refreshRetryInterval := time.Millisecond * 10
 
 	c := sturdyc.New[string](capacity, numShards, ttl, evictionPercentage,
 		sturdyc.WithNoContinuousEvictions(),
-		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, refreshRetryInterval),
+		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, synchronousRefreshDelay, refreshRetryInterval),
 		sturdyc.WithClock(clock),
 	)
 
@@ -648,11 +657,12 @@ func TestGetFetchBatchConvertsDeletedRecordsToMissingRecords(t *testing.T) {
 	clock := sturdyc.NewTestClock(time.Now())
 	minRefreshDelay := time.Millisecond * 500
 	maxRefreshDelay := time.Second
+	synchronousRefreshDelay := time.Minute
 	refreshRetryInterval := time.Millisecond * 10
 
 	c := sturdyc.New[string](capacity, numShards, ttl, evictionPercentage,
 		sturdyc.WithNoContinuousEvictions(),
-		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, refreshRetryInterval),
+		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, synchronousRefreshDelay, refreshRetryInterval),
 		sturdyc.WithMissingRecordStorage(),
 		sturdyc.WithClock(clock),
 	)

--- a/inflight.go
+++ b/inflight.go
@@ -33,7 +33,7 @@ func makeCall[T, V any](ctx context.Context, c *Client[T], key string, fn FetchF
 	}()
 
 	response, err := fn(ctx)
-	if err != nil && c.storeMissingRecords && errors.Is(err, ErrNotFound) {
+	if c.storeMissingRecords && errors.Is(err, ErrNotFound) {
 		c.StoreMissingRecord(key)
 		call.err = ErrMissingRecord
 		return

--- a/keys.go
+++ b/keys.go
@@ -92,6 +92,15 @@ func (c *Client[T]) handleTime(v reflect.Value) string {
 // Returns:
 //
 //	A string to be used as the cache key.
+//
+// Example usage:
+//
+//	type queryParams struct {
+//		City               string
+//		Country            string
+//	}
+//	params := queryParams{"Stockholm", "Sweden"}
+//	key := c.PermutatedKey("prefix",, params) // prefix-Stockholm-Sweden-1
 func (c *Client[T]) PermutatedKey(prefix string, permutationStruct interface{}) string {
 	var sb strings.Builder
 	sb.WriteString(prefix)
@@ -158,8 +167,9 @@ func (c *Client[T]) PermutatedKey(prefix string, permutationStruct interface{}) 
 }
 
 // BatchKeyFn provides a function that can be used in conjunction with
-// "GetOrFetchBatch". It takes in a prefix and returns a function that will
-// append the ID as a suffix for each item.
+// "GetOrFetchBatch". It takes in a prefix and returns a function that will use
+// the prefix, add a -ID- separator, and then append the ID as a suffix for
+// each item.
 //
 // Parameters:
 //
@@ -168,6 +178,11 @@ func (c *Client[T]) PermutatedKey(prefix string, permutationStruct interface{}) 
 // Returns:
 //
 //	A function that takes an ID and returns a cache key string with the given prefix and ID.
+//
+// Example usage:
+//
+//	fn := c.BatchKeyFn("some-prefix")
+//	key := fn("1234") // some-prefix-ID-1234
 func (c *Client[T]) BatchKeyFn(prefix string) KeyFn {
 	return func(id string) string {
 		return fmt.Sprintf("%s-ID-%s", prefix, id)
@@ -190,6 +205,16 @@ func (c *Client[T]) BatchKeyFn(prefix string) KeyFn {
 // Returns:
 //
 //	A function that takes an ID and returns a cache key string with the given prefix, permutation struct fields, and ID.
+//
+// Example usage:
+//
+//	type queryParams struct {
+//		City               string
+//		Country            string
+//	}
+//	params := queryParams{"Stockholm", "Sweden"}
+//	cacheKeyFunc := c.PermutatedBatchKeyFn("prefix", params)
+//	key := cacheKeyFunc("1") // prefix-Stockholm-Sweden-ID-1
 func (c *Client[T]) PermutatedBatchKeyFn(prefix string, permutationStruct interface{}) KeyFn {
 	return func(id string) string {
 		key := c.PermutatedKey(prefix, permutationStruct)

--- a/metrics.go
+++ b/metrics.go
@@ -33,7 +33,7 @@ type DistributedMetricsRecorder interface {
 	DistributedCacheMiss()
 	// DistributedRefresh is called when we retrieve a record from
 	// the distributed storage that should be refreshed.
-	DistributedRefresh() // TODO: Should this be renamed to DistributedBackgroundRefresh? And should we add DistributedSynchronousRefresh?
+	DistributedRefresh()
 	// DistributedMissingRecord is called when we retrieve a record from the
 	// distributed storage that has been marked as a missing record.
 	DistributedMissingRecord()

--- a/metrics.go
+++ b/metrics.go
@@ -5,8 +5,8 @@ type MetricsRecorder interface {
 	CacheHit()
 	// CacheMiss is called for every key that results in a cache miss.
 	CacheMiss()
-	// Refresh is called when a get operation results in a refresh.
-	BackgroundRefresh()
+	// AsynchronousRefresh is called when a get operation results in an asynchronous refresh.
+	AsynchronousRefresh()
 	// SynchronousRefresh is called when a get operation results in a synchronous refresh.
 	SynchronousRefresh()
 	// MissingRecord is called every time the cache is asked to
@@ -73,7 +73,7 @@ func (s *shard[T]) reportEntriesEvicted(n int) {
 }
 
 // reportCacheHits is used to report cache hits and misses to the metrics recorder.
-func (c *Client[T]) reportCacheHits(cacheHit, missingRecord, backgroundRefresh, synchronousRefresh bool) {
+func (c *Client[T]) reportCacheHits(cacheHit, missingRecord, asyncRefresh, syncRefresh bool) {
 	if c.metricsRecorder == nil {
 		return
 	}
@@ -82,11 +82,11 @@ func (c *Client[T]) reportCacheHits(cacheHit, missingRecord, backgroundRefresh, 
 		c.metricsRecorder.MissingRecord()
 	}
 
-	if backgroundRefresh {
-		c.metricsRecorder.BackgroundRefresh()
+	if asyncRefresh {
+		c.metricsRecorder.AsynchronousRefresh()
 	}
 
-	if synchronousRefresh {
+	if syncRefresh {
 		c.metricsRecorder.SynchronousRefresh()
 	}
 

--- a/options.go
+++ b/options.go
@@ -52,16 +52,20 @@ func WithMissingRecordStorage() Option {
 // WithEarlyRefreshes instructs the cache to refresh the keys that are in
 // active rotation, thereby preventing them from ever expiring. This can have a
 // significant impact on your application's latency as you're able to
-// continuously serve frequently used keys from memory. The background refresh
-// gets scheduled when the key is requested again after a random time between
-// minRefreshTime and maxRefreshTime. This is an important distinction because
-// it means that the cache won't just naively refresh every key it's ever seen.
-func WithEarlyRefreshes(minRefreshTime, maxRefreshTime, synchronousRefresthTime, retryBaseDelay time.Duration) Option {
+// continuously serve frequently used keys from memory. An asynchronous
+// background refresh gets scheduled when a key is requested again after a
+// random time between minRefreshTime and maxRefreshTime has passed. This is an
+// important distinction because it means that the cache won't just naively
+// refresh every key it's ever seen. The third argument to this function will
+// also allow you to provide a duration for when a refresh should become
+// synchronous. If any of the refreshes were to fail, you'll get the latest
+// data from the cache for the duration of the TTL.
+func WithEarlyRefreshes(minAsyncRefreshTime, maxAsyncRefreshTime, syncRefreshTime, retryBaseDelay time.Duration) Option {
 	return func(c *Config) {
 		c.earlyRefreshes = true
-		c.minRefreshTime = minRefreshTime
-		c.maxRefreshTime = maxRefreshTime
-		c.synchronousRefreshTime = synchronousRefresthTime
+		c.minAsyncRefreshTime = minAsyncRefreshTime
+		c.maxAsyncRefreshTime = maxAsyncRefreshTime
+		c.syncRefreshTime = syncRefreshTime
 		c.retryBaseDelay = retryBaseDelay
 	}
 }
@@ -163,7 +167,7 @@ func validateConfig(capacity, numShards int, ttl time.Duration, evictionPercenta
 	}
 
 	if !cfg.earlyRefreshes && cfg.bufferRefreshes {
-		panic("refresh buffering requires background refreshes to be enabled")
+		panic("refresh buffering requires early refreshes to be enabled")
 	}
 
 	if cfg.bufferRefreshes && cfg.bufferSize < 1 {
@@ -178,11 +182,11 @@ func validateConfig(capacity, numShards int, ttl time.Duration, evictionPercenta
 		panic("evictionInterval must be greater than 0")
 	}
 
-	if cfg.minRefreshTime > cfg.maxRefreshTime {
+	if cfg.minAsyncRefreshTime > cfg.maxAsyncRefreshTime {
 		panic("minRefreshTime must be less than or equal to maxRefreshTime")
 	}
 
-	if cfg.maxRefreshTime > cfg.synchronousRefreshTime {
+	if cfg.maxAsyncRefreshTime > cfg.syncRefreshTime {
 		panic("maxRefreshTime must be less than or equal to synchronousRefreshTime")
 	}
 

--- a/options_test.go
+++ b/options_test.go
@@ -91,7 +91,7 @@ func TestPanicsIfTheRefreshBufferSizeIsLessThanOne(t *testing.T) {
 		}
 	}()
 	sturdyc.New[string](100, 10, time.Minute, 5,
-		sturdyc.WithEarlyRefreshes(time.Minute, time.Hour, time.Second),
+		sturdyc.WithEarlyRefreshes(time.Minute, time.Hour, time.Hour*2, time.Second),
 		sturdyc.WithRefreshCoalescing(0, time.Minute),
 	)
 }
@@ -106,7 +106,7 @@ func TestPanicsIfTheRefreshBufferTimeoutIsLessThanOne(t *testing.T) {
 		}
 	}()
 	sturdyc.New[string](100, 10, time.Minute, 5,
-		sturdyc.WithEarlyRefreshes(time.Minute, time.Hour, time.Second),
+		sturdyc.WithEarlyRefreshes(time.Minute, time.Hour, time.Hour*2, time.Second),
 		sturdyc.WithRefreshCoalescing(10, 0),
 	)
 }
@@ -135,7 +135,21 @@ func TestPanicsIfTheMinRefreshTimeIsGreaterThanTheMaxRefreshTime(t *testing.T) {
 		}
 	}()
 	sturdyc.New[string](100, 10, time.Minute, 5,
-		sturdyc.WithEarlyRefreshes(time.Hour, time.Minute, time.Second),
+		sturdyc.WithEarlyRefreshes(time.Hour, time.Minute, time.Hour*2, time.Second),
+	)
+}
+
+func TestPanicsIfTheBackgroundRefreshTimeIsGreaterThanTheSynchronousRefreshTime(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		err := recover()
+		if err == nil {
+			t.Error("expected a panic when trying to use a greater background refresh time than the synchronous refresh time")
+		}
+	}()
+	sturdyc.New[string](100, 10, time.Minute, 5,
+		sturdyc.WithEarlyRefreshes(time.Minute, time.Hour*2, time.Hour*1, time.Second),
 	)
 }
 
@@ -149,6 +163,6 @@ func TestPanicsIfTheRetryBaseDelayIsLessThanZero(t *testing.T) {
 		}
 	}()
 	sturdyc.New[string](100, 10, time.Minute, 5,
-		sturdyc.WithEarlyRefreshes(time.Minute, time.Hour, -1),
+		sturdyc.WithEarlyRefreshes(time.Minute, time.Hour, time.Hour*2, -1),
 	)
 }

--- a/passthrough_test.go
+++ b/passthrough_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/viccon/sturdyc"
 	"github.com/google/go-cmp/cmp"
+	"github.com/viccon/sturdyc"
 )
 
 func TestPassthrough(t *testing.T) {

--- a/refresh.go
+++ b/refresh.go
@@ -28,7 +28,7 @@ func (c *Client[T]) refreshBatch(ids []string, keyFn KeyFn, fetchFn BatchFetchFn
 
 	// Check if any of the records have been deleted at the data source.
 	for _, id := range ids {
-		_, okCache, _, _ := c.getWithState(keyFn(id))
+		_, okCache, _, _, _ := c.getWithState(keyFn(id))
 		_, okResponse := response[id]
 
 		if okResponse {

--- a/safe.go
+++ b/safe.go
@@ -36,11 +36,6 @@ func wrap[T, V any](fetchFn FetchFn[V]) FetchFn[T] {
 }
 
 func unwrap[V, T any](val T, err error) (V, error) {
-	if err != nil {
-		var zero V
-		return zero, err
-	}
-
 	v, ok := any(val).(V)
 	if !ok {
 		return v, ErrInvalidType

--- a/shard.go
+++ b/shard.go
@@ -169,11 +169,11 @@ func (s *shard[T]) set(key string, value T, isMissingRecord bool) bool {
 		// If there is a difference between the min- and maxRefreshTime we'll use that to
 		// set a random padding so that the refreshes get spread out evenly over time.
 		var padding time.Duration
-		if s.minRefreshTime != s.maxRefreshTime {
-			padding = time.Duration(rand.Int64N(int64(s.maxRefreshTime - s.minRefreshTime)))
+		if s.minAsyncRefreshTime != s.maxAsyncRefreshTime {
+			padding = time.Duration(rand.Int64N(int64(s.maxAsyncRefreshTime - s.minAsyncRefreshTime)))
 		}
-		newEntry.backgroundRefreshAt = now.Add(s.minRefreshTime + padding)
-		newEntry.synchronousRefreshAt = now.Add(s.synchronousRefreshTime)
+		newEntry.backgroundRefreshAt = now.Add(s.minAsyncRefreshTime + padding)
+		newEntry.synchronousRefreshAt = now.Add(s.syncRefreshTime)
 		newEntry.numOfRefreshRetries = 0
 	}
 

--- a/shard.go
+++ b/shard.go
@@ -8,12 +8,13 @@ import (
 
 // entry represents a single cache entry.
 type entry[T any] struct {
-	key                 string
-	value               T
-	expiresAt           time.Time
-	refreshAt           time.Time
-	numOfRefreshRetries int
-	isMissingRecord     bool
+	key                  string
+	value                T
+	expiresAt            time.Time
+	backgroundRefreshAt  time.Time
+	synchronousRefreshAt time.Time
+	numOfRefreshRetries  int
+	isMissingRecord      bool
 }
 
 // shard is a thread-safe data structure that holds a subset of the cache entries.
@@ -79,7 +80,7 @@ func (s *shard[T]) forceEvict() {
 	s.reportEntriesEvicted(entriesEvicted)
 }
 
-// get retrieves attempts to retrieve a value from the shard.
+// get attempts to retrieve a value from the shard.
 //
 // Parameters:
 //
@@ -91,20 +92,25 @@ func (s *shard[T]) forceEvict() {
 //	exists: A boolean indicating if the value exists in the shard.
 //	markedAsMissing: A boolean indicating if the key has been marked as a missing record.
 //	refresh: A boolean indicating if the value should be refreshed in the background.
-func (s *shard[T]) get(key string) (val T, exists, markedAsMissing, refresh bool) {
+func (s *shard[T]) get(key string) (val T, exists, markedAsMissing, backgroundRefresh, synchronousRefresh bool) {
 	s.RLock()
 	item, ok := s.entries[key]
 	if !ok {
 		s.RUnlock()
-		return val, false, false, false
+		return val, false, false, false, false
 	}
 
 	if s.clock.Now().After(item.expiresAt) {
 		s.RUnlock()
-		return val, false, false, false
+		return val, false, false, false, false
 	}
 
-	shouldRefresh := s.refreshInBackground && s.clock.Now().After(item.refreshAt)
+	// Check if the record should be synchronously refreshed.
+	if s.earlyRefreshes && s.clock.Now().After(item.synchronousRefreshAt) {
+		return item.value, true, item.isMissingRecord, false, true
+	}
+
+	shouldRefresh := s.earlyRefreshes && s.clock.Now().After(item.backgroundRefreshAt)
 	if shouldRefresh {
 		// Release the read lock, and switch to a write lock.
 		s.RUnlock()
@@ -113,22 +119,22 @@ func (s *shard[T]) get(key string) (val T, exists, markedAsMissing, refresh bool
 		// However, during the time it takes to switch locks, another goroutine
 		// might have acquired it and moved the refreshAt. Therefore, we'll have to
 		// check if this operation should still be performed.
-		if !s.clock.Now().After(item.refreshAt) {
+		if !s.clock.Now().After(item.backgroundRefreshAt) {
 			s.Unlock()
-			return item.value, true, item.isMissingRecord, false
+			return item.value, true, item.isMissingRecord, false, false
 		}
 
 		// Update the "refreshAt" so no other goroutines attempts to refresh the same entry.
 		nextRefresh := s.retryBaseDelay * (1 << item.numOfRefreshRetries)
-		item.refreshAt = s.clock.Now().Add(nextRefresh)
+		item.backgroundRefreshAt = s.clock.Now().Add(nextRefresh)
 		item.numOfRefreshRetries++
 
 		s.Unlock()
-		return item.value, true, item.isMissingRecord, shouldRefresh
+		return item.value, true, item.isMissingRecord, shouldRefresh, false
 	}
 
 	s.RUnlock()
-	return item.value, true, item.isMissingRecord, false
+	return item.value, true, item.isMissingRecord, false, false
 }
 
 // set writes a key-value pair to the shard and returns a
@@ -158,14 +164,15 @@ func (s *shard[T]) set(key string, value T, isMissingRecord bool) bool {
 		isMissingRecord: isMissingRecord,
 	}
 
-	if s.refreshInBackground {
+	if s.earlyRefreshes {
 		// If there is a difference between the min- and maxRefreshTime we'll use that to
 		// set a random padding so that the refreshes get spread out evenly over time.
 		var padding time.Duration
 		if s.minRefreshTime != s.maxRefreshTime {
 			padding = time.Duration(rand.Int64N(int64(s.maxRefreshTime - s.minRefreshTime)))
 		}
-		newEntry.refreshAt = now.Add(s.minRefreshTime + padding)
+		newEntry.backgroundRefreshAt = now.Add(s.minRefreshTime + padding)
+		newEntry.synchronousRefreshAt = now.Add(s.synchronousRefreshTime)
 		newEntry.numOfRefreshRetries = 0
 	}
 

--- a/shard.go
+++ b/shard.go
@@ -107,6 +107,7 @@ func (s *shard[T]) get(key string) (val T, exists, markedAsMissing, backgroundRe
 
 	// Check if the record should be synchronously refreshed.
 	if s.earlyRefreshes && s.clock.Now().After(item.synchronousRefreshAt) {
+		s.RUnlock()
 		return item.value, true, item.isMissingRecord, false, true
 	}
 

--- a/sturdyc_test.go
+++ b/sturdyc_test.go
@@ -24,15 +24,16 @@ func randKey(n int) string {
 
 type TestMetricsRecorder struct {
 	sync.Mutex
-	cacheHits       int
-	cacheMisses     int
-	refreshes       int
-	missingRecords  int
-	evictions       int
-	forcedEvictions int
-	evictedEntries  int
-	shards          map[int]int
-	batchSizes      []int
+	cacheHits            int
+	cacheMisses          int
+	backgroundRefreshes  int
+	synchronousRefreshes int
+	missingRecords       int
+	evictions            int
+	forcedEvictions      int
+	evictedEntries       int
+	shards               map[int]int
+	batchSizes           []int
 }
 
 func newTestMetricsRecorder(numShards int) *TestMetricsRecorder {
@@ -54,10 +55,16 @@ func (r *TestMetricsRecorder) CacheMiss() {
 	r.cacheMisses++
 }
 
-func (r *TestMetricsRecorder) Refresh() {
+func (r *TestMetricsRecorder) BackgroundRefresh() {
 	r.Lock()
 	defer r.Unlock()
-	r.refreshes++
+	r.backgroundRefreshes++
+}
+
+func (r *TestMetricsRecorder) SynchronousRefresh() {
+	r.Lock()
+	defer r.Unlock()
+	r.synchronousRefreshes++
 }
 
 func (r *TestMetricsRecorder) MissingRecord() {

--- a/sturdyc_test.go
+++ b/sturdyc_test.go
@@ -55,7 +55,7 @@ func (r *TestMetricsRecorder) CacheMiss() {
 	r.cacheMisses++
 }
 
-func (r *TestMetricsRecorder) BackgroundRefresh() {
+func (r *TestMetricsRecorder) AsynchronousRefresh() {
 	r.Lock()
 	defer r.Unlock()
 	r.backgroundRefreshes++


### PR DESCRIPTION
## Overview
This PR adds another argument to the `WithEarlyRefreshes` option which allows us to provide a duration for synchronous refreshes. It also adds the possibility to get metrics for these as well as some changes to the documentation