### PR TITLE
GetOrFetch: Don't attempt unwrap if err != nil

### DIFF
--- a/fetch.go
+++ b/fetch.go
@@ -123,6 +123,10 @@ func (c *Client[T]) GetOrFetch(ctx context.Context, key string, fetchFn FetchFn[
 //	T - The type stored in the cache.
 func GetOrFetch[V, T any](ctx context.Context, c *Client[T], key string, fetchFn FetchFn[V]) (V, error) {
 	res, err := getFetch[V, T](ctx, c, key, fetchFn)
+	if err != nil {
+		var zero V
+		return zero, err
+	}
 	return unwrap[V](res, err)
 }
 

--- a/fetch.go
+++ b/fetch.go
@@ -231,5 +231,9 @@ func (c *Client[T]) GetOrFetchBatch(ctx context.Context, ids []string, keyFn Key
 
 func GetOrFetchBatch[V, T any](ctx context.Context, c *Client[T], ids []string, keyFn KeyFn, fetchFn BatchFetchFn[V]) (map[string]V, error) {
 	res, err := getFetchBatch[V, T](ctx, c, ids, keyFn, fetchFn)
+	if err != nil {
+		var zero map[string]V
+		return zero, err
+	}
 	return unwrapBatch[V](res, err)
 }


### PR DESCRIPTION
**Problem**: If `fetchFn` returns an error, we still attempt an unwrap and `ErrInvalidType` is (most likely) returned [here](https://github.com/viccon/sturdyc/blob/d5004d81106b11cc054b498bf9bc03b57e6e5adc/safe.go#L41). The original error is not logged, which causes problems in observability.

**Proposed solution**: Don't attempt to unwrap if `fetchFn` returns an error, instead return that error immediately.

**Alternative solution**: Another option could be to still attempt the unwrap, but do an `errors.Join` with the original error like in #33 if the type assertion fails.  But I don't think this makes as much sense.

Not tested yet, but opening a PR to see what you think. Maybe there are some tests which should also be updated?