### PR TITLE
Return the actual error instead of ErrInvalidType

### DIFF
--- a/fetch.go
+++ b/fetch.go
@@ -176,11 +176,10 @@ func getFetchBatch[V, T any](ctx context.Context, c *Client[T], ids []string, ke
 
 	if err != nil && !errors.Is(err, ErrOnlyCachedRecords) {
 		if len(cachedRecords) > 0 {
+			maps.Copy(cachedRecords, response)
 			return cachedRecords, errors.Join(ErrOnlyCachedRecords, err)
 		}
-		return cachedRecords, err
 	}
-
 	maps.Copy(cachedRecords, response)
 	return cachedRecords, err
 }

--- a/fetch.go
+++ b/fetch.go
@@ -151,7 +151,7 @@ func getFetchBatch[V, T any](ctx context.Context, c *Client[T], ids []string, ke
 	cacheMissesAndSyncRefreshes = append(cacheMissesAndSyncRefreshes, cacheMisses...)
 	cacheMissesAndSyncRefreshes = append(cacheMissesAndSyncRefreshes, idsToSynchronouslyRefresh...)
 
-	callBatchOpts := callBatchOpts[T, T]{ids: cacheMissesAndSyncRefreshes, keyFn: keyFn, fn: wrappedFetch}
+	callBatchOpts := callBatchOpts[T]{ids: cacheMissesAndSyncRefreshes, keyFn: keyFn, fn: wrappedFetch}
 	response, err := callAndCacheBatch(ctx, c, callBatchOpts)
 
 	// If we did a call to synchronously refresh some of the records, and it
@@ -175,11 +175,16 @@ func getFetchBatch[V, T any](ctx context.Context, c *Client[T], ids []string, ke
 	}
 
 	if err != nil && !errors.Is(err, ErrOnlyCachedRecords) {
+		// At this point, the call for the IDs that we didn't have in the cache
+		// have failed. However, these ID's could have been picked from multiple
+		// in-flight requests. Hence, we'll check if we're able to add any of these
+		// IDs to the cached records before returning.
 		if len(cachedRecords) > 0 {
 			maps.Copy(cachedRecords, response)
 			return cachedRecords, errors.Join(ErrOnlyCachedRecords, err)
 		}
 	}
+
 	maps.Copy(cachedRecords, response)
 	return cachedRecords, err
 }

--- a/inflight.go
+++ b/inflight.go
@@ -21,7 +21,7 @@ func (c *Client[T]) newFlight(key string) *inFlightCall[T] {
 	return call
 }
 
-func makeCall[T, V any](ctx context.Context, c *Client[T], key string, fn FetchFn[V], call *inFlightCall[T]) {
+func makeCall[T any](ctx context.Context, c *Client[T], key string, fn FetchFn[T], call *inFlightCall[T]) {
 	defer func() {
 		if err := recover(); err != nil {
 			call.err = fmt.Errorf("sturdyc: panic recovered: %v", err)
@@ -33,12 +33,6 @@ func makeCall[T, V any](ctx context.Context, c *Client[T], key string, fn FetchF
 	}()
 
 	response, err := fn(ctx)
-	valueAsT, valueIsAssignableToT := any(response).(T)
-	if !valueIsAssignableToT {
-		call.err = ErrInvalidType
-		return
-	}
-	call.val = valueAsT
 
 	if c.storeMissingRecords && errors.Is(err, ErrNotFound) {
 		c.StoreMissingRecord(key)
@@ -46,27 +40,27 @@ func makeCall[T, V any](ctx context.Context, c *Client[T], key string, fn FetchF
 		return
 	}
 
+	call.val = response
+	call.err = err
 	if err != nil {
-		call.err = err
 		return
 	}
 
-	call.err = nil
-	c.Set(key, valueAsT)
+	c.Set(key, response)
 }
 
-func callAndCache[V, T any](ctx context.Context, c *Client[T], key string, fn FetchFn[V]) (V, error) {
+func callAndCache[T any](ctx context.Context, c *Client[T], key string, fn FetchFn[T]) (T, error) {
 	c.inFlightMutex.Lock()
 	if call, ok := c.inFlightMap[key]; ok {
 		c.inFlightMutex.Unlock()
 		call.Wait()
-		return unwrap[V, T](call.val, call.err)
+		return call.val, call.err
 	}
 
 	call := c.newFlight(key)
 	c.inFlightMutex.Unlock()
 	makeCall(ctx, c, key, fn, call)
-	return unwrap[V, T](call.val, call.err)
+	return call.val, call.err
 }
 
 // newBatchFlight should be called with a lock.

--- a/inflight.go
+++ b/inflight.go
@@ -33,6 +33,7 @@ func makeCall[T any](ctx context.Context, c *Client[T], key string, fn FetchFn[T
 	}()
 
 	response, err := fn(ctx)
+	call.val = response
 
 	if c.storeMissingRecords && errors.Is(err, ErrNotFound) {
 		c.StoreMissingRecord(key)
@@ -40,7 +41,6 @@ func makeCall[T any](ctx context.Context, c *Client[T], key string, fn FetchFn[T
 		return
 	}
 
-	call.val = response
 	call.err = err
 	if err != nil {
 		return

--- a/inflight.go
+++ b/inflight.go
@@ -103,6 +103,9 @@ func makeBatchCall[T, V any](ctx context.Context, c *Client[T], opts makeBatchCa
 	for id, record := range response {
 		if v, ok := any(record).(T); ok {
 			opts.call.val[id] = v
+			if err == nil || errors.Is(err, errOnlyDistributedRecords) {
+				c.Set(opts.keyFn(id), v)
+			}
 		}
 	}
 
@@ -125,13 +128,6 @@ func makeBatchCall[T, V any](ctx context.Context, c *Client[T], opts makeBatchCa
 			if _, ok := response[id]; !ok {
 				c.StoreMissingRecord(opts.keyFn(id))
 			}
-		}
-	}
-
-	// Store the records in the cache.
-	for id, record := range response {
-		if v, ok := any(record).(T); ok {
-			c.Set(opts.keyFn(id), v)
 		}
 	}
 }

--- a/inflight.go
+++ b/inflight.go
@@ -34,13 +34,11 @@ func makeCall[T, V any](ctx context.Context, c *Client[T], key string, fn FetchF
 
 	response, err := fn(ctx)
 	valueAsT, valueIsAssignableToT := any(response).(T)
-	if valueIsAssignableToT {
-		call.val = valueAsT
-	}
 	if !valueIsAssignableToT {
 		call.err = ErrInvalidType
 		return
 	}
+	call.val = valueAsT
 
 	if c.storeMissingRecords && errors.Is(err, ErrNotFound) {
 		c.StoreMissingRecord(key)

--- a/inflight.go
+++ b/inflight.go
@@ -173,7 +173,7 @@ func callAndCacheBatch[V, T any](ctx context.Context, c *Client[T], opts callBat
 		call.Wait()
 
 		// We need to iterate through the values that WE want from this call. The batch
-		// could contain hundrdreds of IDs, but we might only want a few of them.
+		// could contain hundreds of IDs, but we might only want a few of them.
 		for _, id := range callIDs {
 			v, ok := call.val[id]
 			if !ok {

--- a/inflight.go
+++ b/inflight.go
@@ -93,7 +93,11 @@ type makeBatchCallOpts[T any] struct {
 func makeBatchCall[T any](ctx context.Context, c *Client[T], opts makeBatchCallOpts[T]) {
 	response, err := opts.fn(ctx, opts.ids)
 	for id, record := range response {
+		// We never want to discard values from the fetch functions, even if they
+		// return an error. Instead, we'll pass them to the user along with any
+		// errors and let them decide what to do.
 		opts.call.val[id] = record
+		// However, we'll only write them to the cache if the fetchFunction returned a non-nil error.
 		if err == nil || errors.Is(err, errOnlyDistributedRecords) {
 			c.Set(opts.keyFn(id), record)
 		}

--- a/passthrough.go
+++ b/passthrough.go
@@ -67,7 +67,7 @@ func Passthrough[T, V any](ctx context.Context, c *Client[T], key string, fetchF
 //	A map of IDs to their corresponding values, and an error if one occurred and
 //	none of the IDs were found in the cache.
 func (c *Client[T]) PassthroughBatch(ctx context.Context, ids []string, keyFn KeyFn, fetchFn BatchFetchFn[T]) (map[string]T, error) {
-	res, err := callAndCacheBatch(ctx, c, callBatchOpts[T, T]{ids, keyFn, fetchFn})
+	res, err := callAndCacheBatch(ctx, c, callBatchOpts[T]{ids, keyFn, fetchFn})
 	if err == nil {
 		return res, nil
 	}

--- a/safe.go
+++ b/safe.go
@@ -21,19 +21,11 @@ func (c *Client[T]) safeGo(fn func()) {
 func wrap[T, V any](fetchFn FetchFn[V]) FetchFn[T] {
 	return func(ctx context.Context) (T, error) {
 		res, err := fetchFn(ctx)
-		if err != nil {
-			if val, ok := any(res).(T); ok {
-				return val, err
-			}
-			var zero T
-			return zero, err
+		if val, ok := any(res).(T); ok {
+			return val, err
 		}
-		val, ok := any(res).(T)
-		if !ok {
-			var zero T
-			return zero, ErrInvalidType
-		}
-		return val, nil
+		var zero T
+		return zero, ErrInvalidType
 	}
 }
 
@@ -42,7 +34,6 @@ func unwrap[V, T any](val T, err error) (V, error) {
 	if !ok {
 		return v, ErrInvalidType
 	}
-
 	return v, err
 }
 


### PR DESCRIPTION
## Overview
As pointed out by @ernstwi [here](https://github.com/viccon/sturdyc/pull/35), the `GetOrFetch` function always returns `ErrInvalidType` errors instead of the actual error. In addition to this, it also throws away the value and returns a zero value of the type instead.

As an example, running this code on **main**:

```go
package main

import (
	"context"
	"errors"
	"log"
	"time"

	"github.com/viccon/sturdyc"
)

type apiClient struct {
	cache *sturdyc.Client[any]
}

func newAPIClient(c *sturdyc.Client[any]) *apiClient {
	return &apiClient{cache: c}
}

func (a *apiClient) OrderStatus(ctx context.Context, id string) (string, error) {
	fetchFn := func(_ context.Context) (string, error) {
		return "Error getting order status", errors.New("something went wrong")
	}
	return sturdyc.GetOrFetch(ctx, a.cache, id, fetchFn)
}

func (a *apiClient) OrderStatusBatch(ctx context.Context, ids []string) (map[string]string, error) {
	cacheKeyFn := a.cache.BatchKeyFn("order-status-batch")
	fetchFn := func(_ context.Context, cacheMisses []string) (map[string]string, error) {
		response := make(map[string]string, len(cacheMisses))
		for _, id := range cacheMisses {
			response[id] = "Error getting order status for ID: " + id
		}
		return response, errors.New("something went wrong with the batch call too")
	}
	return sturdyc.GetOrFetchBatch(ctx, a.cache, ids, cacheKeyFn, fetchFn)
}

func main() {
	capacity := 10000
	numShards := 10
	ttl := 2 * time.Hour
	evictionPercentage := 10
	minRefreshDelay := time.Second
	maxRefreshDelay := time.Second * 2
	synchronousRefreshDelay := time.Second * 30
	retryBaseDelay := time.Millisecond * 10

	// Create a new cache client with the specified configuration.
	cacheClient := sturdyc.New[any](capacity, numShards, ttl, evictionPercentage,
		sturdyc.WithEarlyRefreshes(minRefreshDelay, maxRefreshDelay, synchronousRefreshDelay, retryBaseDelay),
		sturdyc.WithRefreshCoalescing(10, time.Second*15),
	)

	api := newAPIClient(cacheClient)

	if res, err := api.OrderStatus(context.Background(), "1"); err != nil {
		log.Println(err)
		log.Println(res)
	}

	ids := []string{"1", "2", "3"}
	if res, err := api.OrderStatusBatch(context.Background(), ids); err != nil {
		log.Println(err)
		for _, val := range res {
			log.Println(val)
		}
	}
}
```

Produces the following output:

```text
❯ go run main.go
2025/03/12 10:59:37 sturdyc: invalid response type
2025/03/12 10:59:37
2025/03/12 10:59:37 something went wrong with the batch call too
```

Running the same code again, with the changes introduces by **this PR**, produces the following:

```text
2025/03/12 11:03:43 something went wrong
2025/03/12 11:03:43 Error getting order status
2025/03/12 11:03:43 something went wrong with the batch call too
2025/03/12 11:03:43 Error getting order status for ID: 1
2025/03/12 11:03:43 Error getting order status for ID: 2
2025/03/12 11:03:43 Error getting order status for ID: 3
```