### PR TITLE
Distributed error handling

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -20,16 +20,40 @@ var (
 	// ErrMissingRecord is returned by client.GetOrFetch and client.Passthrough when a record has been marked
 	// as missing. The cache will still try to refresh the record in the background if it's being requested.
 	ErrMissingRecord = errors.New("sturdyc: the record has been marked as missing in the cache")
-	// ErrOnlyCachedRecords is returned by client.GetOrFetchBatch and
-	// client.PassthroughBatch when some of the requested records are available
-	// in the cache, but the attempt to fetch the remaining records failed. It
-	// may also be returned when you're using the WithEarlyRefreshes
-	// functionality, and the call to synchronously refresh a record failed. The
-	// cache will then give you the latest data it has cached, and you as the
-	// consumer can then decide whether to proceed with the cached records or if
-	// the newest data is necessary.
+	// ErrOnlyCachedRecords can be returned when you're using the cache with
+	// early refreshes or distributed storage functionality. It indicates that
+	// the records *should* have been refreshed from the underlying data source,
+	// but the operation failed. It is up to you to decide whether you want to
+	// proceed with the records that were retrieved from the cache. Note: For
+	// batch operations, this might contain only part of the batch. For example,
+	// if you requested keys 1-10, and we had IDs 1-3 in the cache, but the
+	// request to fetch records 4-10 failed.
 	ErrOnlyCachedRecords = errors.New("sturdyc: failed to fetch the records that were not in the cache")
 	// ErrInvalidType is returned when you try to use one of the generic
 	// package level functions but the type assertion fails.
 	ErrInvalidType = errors.New("sturdyc: invalid response type")
 )
+
+// onlyCachedRecords is used when we were able to successfully retrieve some
+// records from distributed storage, but the request to get additional records
+// from the underlying data source failed. In this case, we wrap any potential
+// errors from the underlying data source with an ErrOnlyCachedRecords to allow
+// the user to decide whether to proceed with the cached records or not.
+func onlyCachedRecords(err error) error {
+	multiErr, isMultiErr := err.(interface{ Unwrap() []error })
+	if !isMultiErr {
+		if errors.Is(errOnlyDistributedRecords, err) {
+			return ErrOnlyCachedRecords
+		}
+		return errors.Join(err, ErrOnlyCachedRecords)
+	}
+
+	var errs []error
+	errs = append(errs, ErrOnlyCachedRecords)
+	for _, e := range multiErr.Unwrap() {
+		if !errors.Is(e, errOnlyDistributedRecords) {
+			errs = append(errs, e)
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/fetch_test.go
+++ b/fetch_test.go
@@ -213,6 +213,44 @@ func TestGetOrFetchMissingRecord(t *testing.T) {
 	fetchObserver.AssertFetchCount(t, 2)
 }
 
+func TestGetOrFetchMissingRecordError(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	capacity := 5
+	numShards := 2
+	ttl := time.Minute
+	evictionPercentage := 10
+	c := sturdyc.New[any](capacity, numShards, ttl, evictionPercentage,
+		sturdyc.WithNoContinuousEvictions(),
+		sturdyc.WithMissingRecordStorage(),
+	)
+
+	// We'll make the fetch observer return an ErrNotFound error
+	// to indicate that the record should be stored as missing.
+	fetchObserver := NewFetchObserver(1)
+	fetchObserver.Err(sturdyc.ErrNotFound)
+	id := "1"
+
+	_, err := sturdyc.GetOrFetch(ctx, c, id, fetchObserver.Fetch)
+	if !errors.Is(err, sturdyc.ErrMissingRecord) {
+		t.Fatalf("expected missing record error, got %v", err)
+	}
+
+	<-fetchObserver.FetchCompleted
+	fetchObserver.AssertFetchCount(t, 1)
+	fetchObserver.Err(sturdyc.ErrNotFound)
+
+	// The second time we call Get, we should still get the missing record
+	_, err = sturdyc.GetOrFetch(ctx, c, id, fetchObserver.Fetch)
+	if !errors.Is(err, sturdyc.ErrMissingRecord) {
+		t.Fatalf("expected missing record error, got %v", err)
+	}
+
+	// And only no more fetch should have been made
+	fetchObserver.AssertFetchCount(t, 1)
+}
+
 func TestGetOrFetchBatch(t *testing.T) {
 	t.Parallel()
 
@@ -1567,4 +1605,244 @@ func TestGetFetchBatchMixOfSynchronousAndAsynchronousRefreshes(t *testing.T) {
 	<-fetchObserver.FetchCompleted
 	fetchObserver.AssertRequestedRecords(t, []string{"4"})
 	fetchObserver.AssertFetchCount(t, 4)
+}
+
+func TestGetOrFetchGenerics(t *testing.T) {
+	t.Parallel()
+
+	capacity := 10
+	numShards := 2
+	ttl := time.Second * 2
+	evictionPercentage := 10
+	c := sturdyc.New[string](capacity, numShards, ttl, evictionPercentage,
+		sturdyc.WithNoContinuousEvictions(),
+	)
+
+	fetchFuncInt := func(_ context.Context) (int, error) {
+		return 1, nil
+	}
+
+	_, err := sturdyc.GetOrFetch(context.Background(), c, "1", fetchFuncInt)
+	if !errors.Is(err, sturdyc.ErrInvalidType) {
+		t.Errorf("expected ErrInvalidType, got %v", err)
+	}
+
+	if _, ok := c.Get("1"); ok {
+		t.Error("we should not have cached anything given that the value was of the wrong type")
+	}
+
+	if c.Size() != 0 {
+		t.Errorf("expected cache size to be 0, got %d", c.Size())
+	}
+
+	fetchFuncString := func(_ context.Context) (string, error) {
+		return "value", nil
+	}
+
+	val, err := sturdyc.GetOrFetch(context.Background(), c, "1", fetchFuncString)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if val != "value" {
+		t.Errorf("expected value to be value, got %v", val)
+	}
+
+	cachedValue, ok := c.Get("1")
+	if !ok {
+		t.Error("expected value to be in the cache")
+	}
+	if cachedValue != "value" {
+		t.Errorf("expected value to be value, got %v", cachedValue)
+	}
+	if c.Size() != 1 {
+		t.Errorf("expected cache size to be 1, got %d", c.Size())
+	}
+}
+
+func TestGetOrFetchBatchGenerics(t *testing.T) {
+	t.Parallel()
+
+	capacity := 10
+	numShards := 2
+	ttl := time.Second * 2
+	evictionPercentage := 10
+	c := sturdyc.New[string](capacity, numShards, ttl, evictionPercentage,
+		sturdyc.WithNoContinuousEvictions(),
+	)
+
+	fetchFuncInt := func(_ context.Context, ids []string) (map[string]int, error) {
+		response := make(map[string]int, len(ids))
+		for i, id := range ids {
+			response[id] = i
+		}
+		return response, nil
+	}
+
+	ids := []string{"1", "2", "3"}
+	_, err := sturdyc.GetOrFetchBatch(context.Background(), c, ids, c.BatchKeyFn("item"), fetchFuncInt)
+	if !errors.Is(err, sturdyc.ErrInvalidType) {
+		t.Errorf("expected ErrInvalidType, got %v", err)
+	}
+	if c.Size() != 0 {
+		t.Errorf("expected cache size to be 0, got %d", c.Size())
+	}
+
+	fetchFuncString := func(_ context.Context, ids []string) (map[string]string, error) {
+		response := make(map[string]string, len(ids))
+		for _, id := range ids {
+			response[id] = "value" + id
+		}
+		return response, nil
+	}
+
+	keyFunc := c.BatchKeyFn("item")
+	values, err := sturdyc.GetOrFetchBatch(context.Background(), c, ids, keyFunc, fetchFuncString)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(values) != 3 {
+		t.Errorf("expected 3 values, got %d", len(values))
+	}
+	if values["1"] != "value1" {
+		t.Errorf("expected value to be value1, got %v", values["1"])
+	}
+	if values["2"] != "value2" {
+		t.Errorf("expected value to be value2, got %v", values["2"])
+	}
+	if values["3"] != "value3" {
+		t.Errorf("expected value to be value3, got %v", values["3"])
+	}
+
+	cacheKeys := make([]string, 0, len(ids))
+	for _, id := range ids {
+		cacheKeys = append(cacheKeys, keyFunc(id))
+	}
+	cachedValues := c.GetMany(cacheKeys)
+	if len(cachedValues) != 3 {
+		t.Errorf("expected 3 values, got %d", len(cachedValues))
+	}
+	if cachedValues[cacheKeys[0]] != "value1" {
+		t.Errorf("expected value to be value1, got %v", cachedValues["1"])
+	}
+	if cachedValues[cacheKeys[1]] != "value2" {
+		t.Errorf("expected value to be value2, got %v", cachedValues["2"])
+	}
+	if cachedValues[cacheKeys[2]] != "value3" {
+		t.Errorf("expected value to be value3, got %v", cachedValues["3"])
+	}
+}
+
+func TestGetOrFetchGenericsClashingTypes(t *testing.T) {
+	t.Parallel()
+
+	capacity := 10
+	numShards := 2
+	ttl := time.Second * 2
+	evictionPercentage := 10
+	c := sturdyc.New[any](capacity, numShards, ttl, evictionPercentage,
+		sturdyc.WithNoContinuousEvictions(),
+	)
+
+	resolve := make(chan struct{})
+	fetchFuncInt := func(_ context.Context) (int, error) {
+		<-resolve
+		return 1, nil
+	}
+	fetchFuncString := func(_ context.Context) (string, error) {
+		return "value", nil
+	}
+
+	go func() {
+		time.Sleep(time.Millisecond * 500)
+		resolve <- struct{}{}
+	}()
+	resOne, errOne := sturdyc.GetOrFetch(context.Background(), c, "1", fetchFuncInt)
+	_, errTwo := sturdyc.GetOrFetch(context.Background(), c, "1", fetchFuncString)
+
+	if errOne != nil {
+		t.Errorf("expected no error, got %v", errOne)
+	}
+	if resOne != 1 {
+		t.Errorf("expected value to be 1, got %v", resOne)
+	}
+
+	if !errors.Is(errTwo, sturdyc.ErrInvalidType) {
+		t.Errorf("expected ErrInvalidType, got %v", errTwo)
+	}
+}
+
+func TestGetOrFetchBatchGenericsClashingTypes(t *testing.T) {
+	t.Parallel()
+
+	capacity := 10
+	numShards := 2
+	ttl := time.Second * 2
+	evictionPercentage := 10
+	c := sturdyc.New[any](capacity, numShards, ttl, evictionPercentage,
+		sturdyc.WithNoContinuousEvictions(),
+	)
+
+	// We are going to test the behaviour for when the same IDs are passed to
+	// fetch functions which return different types.
+	cacheKeyFunc := c.BatchKeyFn("item")
+	firstCallIDs := []string{"1", "2", "3"}
+	secondCallIDs := []string{"1", "2", "3", "4"}
+
+	// First, we'll create a fetch function which returns integers. This fetch
+	// function is going to wait for a message on the resolve channel before
+	// returning. This is so that we're able to create an in-flight batch for the
+	// first set of IDs.
+	resolve := make(chan struct{})
+	fetchFuncInt := func(_ context.Context, ids []string) (map[string]int, error) {
+		if len(ids) != 3 {
+			t.Fatalf("expected 3 IDs, got %d", len(ids))
+		}
+		response := make(map[string]int, len(ids))
+		for i, id := range ids {
+			response[id] = i + 1
+		}
+		<-resolve
+		return response, nil
+	}
+
+	// Next, we'll create a fetch function which returns strings. This fetch
+	// function should only be called with ID "4" because IDs 1-3 are picked from
+	// the first batch.
+	fetchFuncString := func(_ context.Context, ids []string) (map[string]string, error) {
+		if len(ids) != 1 {
+			t.Fatalf("expected 1 ID, got %d", len(ids))
+		}
+		response := make(map[string]string, len(ids))
+		for _, id := range ids {
+			response[id] = "value" + id
+		}
+		return response, nil
+	}
+
+	go func() {
+		time.Sleep(time.Millisecond * 500)
+		resolve <- struct{}{}
+	}()
+	firstCallValues, firstCallErr := sturdyc.GetOrFetchBatch(context.Background(), c, firstCallIDs, cacheKeyFunc, fetchFuncInt)
+	_, secondCallErr := sturdyc.GetOrFetchBatch(context.Background(), c, secondCallIDs, cacheKeyFunc, fetchFuncString)
+
+	if firstCallErr != nil {
+		t.Errorf("expected no error, got %v", firstCallErr)
+	}
+	if len(firstCallValues) != 3 {
+		t.Errorf("expected 3 values, got %d", len(firstCallValues))
+	}
+	if firstCallValues["1"] != 1 {
+		t.Errorf("expected value to be 1, got %v", firstCallValues["1"])
+	}
+	if firstCallValues["2"] != 2 {
+		t.Errorf("expected value to be 2, got %v", firstCallValues["2"])
+	}
+	if firstCallValues["3"] != 3 {
+		t.Errorf("expected value to be 3, got %v", firstCallValues["3"])
+	}
+
+	if !errors.Is(secondCallErr, sturdyc.ErrInvalidType) {
+		t.Errorf("expected ErrInvalidType, got %v", secondCallErr)
+	}
 }

--- a/passthrough.go
+++ b/passthrough.go
@@ -67,7 +67,7 @@ func Passthrough[T, V any](ctx context.Context, c *Client[T], key string, fetchF
 //	A map of IDs to their corresponding values, and an error if one occurred and
 //	none of the IDs were found in the cache.
 func (c *Client[T]) PassthroughBatch(ctx context.Context, ids []string, keyFn KeyFn, fetchFn BatchFetchFn[T]) (map[string]T, error) {
-	res, err := callAndCacheBatch(ctx, c, callBatchOpts[T, T]{ids, keyFn, fetchFn})
+	res, err := callAndCacheBatch(ctx, c, callBatchOpts[T]{ids, keyFn, fetchFn})
 	if err == nil {
 		return res, nil
 	}

--- a/refresh.go
+++ b/refresh.go
@@ -7,7 +7,7 @@ import (
 
 func (c *Client[T]) refresh(key string, fetchFn FetchFn[T]) {
 	response, err := fetchFn(context.Background())
-	if err != nil {
+	if err != nil && !errors.Is(err, errOnlyDistributedRecords) {
 		if c.storeMissingRecords && errors.Is(err, ErrNotFound) {
 			c.StoreMissingRecord(key)
 		}


### PR DESCRIPTION
## Overview
This PR should resolve #38 by ensuring that either the error from the fetch function is returned when no distributed records are found, or a combination of `ErrOnlyCachedRecords` and the fetch function error when part of a batch was retrievable from the distributed storage.

**Note:** In this PR, I've branched from #36 as they are both related to error handling, and I'll most likely include them in the same release.