### PR TITLE
fix: don't unwrap when not found error is thrown

### DIFF
--- a/safe.go
+++ b/safe.go
@@ -36,6 +36,11 @@ func wrap[T, V any](fetchFn FetchFn[V]) FetchFn[T] {
 }
 
 func unwrap[V, T any](val T, err error) (V, error) {
+	if errors.Is(err, ErrMissingRecord) || errors.Is(err, ErrNotFound) {
+		var zero V
+		return zero, err
+	}
+
 	v, ok := any(val).(V)
 	if !ok {
 		return v, ErrInvalidType


### PR DESCRIPTION
When we have a `sturdyc.Client[any]` we run into errors when we have missing records.

It seems like the cache is trying to do unwrap on the values even when we have told the cache that the result isn't found. This is not an issue when we have `sturdyc.Client[FancyStruct]` but happens when we have `any`.

I believe it is since when that happens and `any=interface{}` causes us to unwrap a nil value and hence we return `ErrInvalidType` instead.